### PR TITLE
Drop "Topic", make form question-first; tighten contexts to "When X"

### DIFF
--- a/app/routes/dashboard.new.tsx
+++ b/app/routes/dashboard.new.tsx
@@ -3,20 +3,14 @@ import {
   Form,
   useActionData,
   useNavigate,
-  useLoaderData,
 } from "@remix-run/react"
 import { useEffect, useState } from "react"
-import { auth, db, inngest } from "~/config.server"
+import { auth, db } from "~/config.server"
 import { Button } from "~/components/ui/button"
 import { Input } from "~/components/ui/input"
 import { Textarea } from "~/components/ui/textarea"
 import { Label } from "~/components/ui/label"
 import LoadingButton from "~/components/loading-button"
-import { RadioGroup, RadioGroupItem } from "~/components/ui/radio-group"
-import {
-  unstable_parseMultipartFormData,
-  unstable_createMemoryUploadHandler,
-} from "@remix-run/node"
 import { toast } from "sonner"
 import {
   Select,
@@ -25,216 +19,80 @@ import {
   SelectTrigger,
   SelectValue,
 } from "~/components/ui/select"
-import {
-  allContexts,
-  generateScenario,
-  parseScenarioGenerationData as parseScenarioGenData,
-} from "~/services/scenario-generation"
-import { seedQuestionsAndContextsCore } from "~/services/generation"
-import { Deliberation } from "@prisma/client"
+import { seedFromGivenQuestionsCore } from "~/services/generation"
+import { Plus, X } from "lucide-react"
 
-/** Fire a background promise that survives the response. Plays nicely
- * both in local Node (the process keeps it alive) and on Vercel
- * serverless (where the lambda will hold for up to maxDuration).
- *
- * Vercel's @vercel/functions exports `waitUntil` for the same purpose;
- * we don't import it to avoid a hard dep on the runtime. */
+/** Fire a background promise that survives the response. */
 function fireAndForget(label: string, fn: () => Promise<unknown>) {
   fn().catch((e) => {
     console.error(`[bg ${label}] ${(e as Error).message}`)
   })
 }
 
-async function handleTopicSubmission(deliberationData: {
-  title: string
-  welcomeText: string
-  topic: string
-  userId: number
-  numQuestions: number
-  numContexts: number
-}) {
-  const { title, welcomeText, topic, userId, numContexts, numQuestions } =
-    deliberationData
-
-  const deliberation = await db.deliberation.create({
-    data: {
-      title,
-      welcomeText,
-      topic,
-      user: { connect: { id: userId } },
-    },
-  })
-
-  // Send the Inngest event for production (where Inngest cloud picks it up).
-  // Don't await — if Inngest isn't configured, we don't want to block.
-  inngest
-    .send({
-      name: "gen-seed-questions-contexts",
-      data: {
-        deliberationId: deliberation.id,
-        topic,
-        numQuestions,
-        numContexts,
-      },
-    })
-    .catch((e) =>
-      console.warn("inngest.send failed (non-fatal):", (e as Error).message)
-    )
-
-  // ALSO run the seed directly as a background promise. This makes the seed
-  // work in local dev (where `npm run inngest` may not be running) and as a
-  // safety net in production. Inngest itself is idempotent on its event id,
-  // and the seed function early-exits if questions already exist (writes are
-  // upserts), so a double-run is harmless.
-  fireAndForget(`seed delib ${deliberation.id}`, () =>
-    seedQuestionsAndContextsCore({
-      deliberationId: deliberation.id,
-      topic,
-      numQuestions,
-      numContexts,
-    })
-  )
-
-  return deliberation
-}
-
-async function handleQuestionsFileSubmission(
-  deliberationData: {
-    title: string
-    welcomeText: string
-    topic: string | null
-    userId: number
-  },
-  questionsFile: File
-) {
-  const { title, welcomeText, topic, userId } = deliberationData
-
-  const questions = (await questionsFile.text())
-    .split("\n")
-    .filter((line) => line.trim())
-    .map((line) => JSON.parse(line))
-
-  if (questions.find((q: any) => !q.question || !q.title)) {
-    throw new Error(
-      "Invalid questions format. Each question must have 'question' and 'title' fields."
-    )
-  }
-
-  const deliberation = await db.deliberation.create({
-    data: {
-      title,
-      welcomeText,
-      topic: topic ?? title,
-      user: { connect: { id: userId } },
-    },
-  })
-
-  const dbQuestions = await Promise.all(
-    questions.map((q: any) =>
-      db.question.create({
-        data: {
-          title: q.title,
-          question: q.question,
-          deliberationId: deliberation.id,
-        },
-      })
-    )
-  )
-
-  await inngest.send({
-    name: "gen-seed-contexts",
-    data: {
-      deliberationId: deliberation.id,
-      questionIds: dbQuestions.map((q) => q.id),
-      topic,
-    },
-  })
-
-  return deliberation
-}
-
-async function handleContextsFileSubmission(
-  deliberationData: {
-    title: string
-    welcomeText: string
-    topic: string | null
-    userId: number
-    numQuestions: number
-  },
-  contextsFile: File
-) {
-  const { title, welcomeText, userId, numQuestions } = deliberationData
-  const data = parseScenarioGenData(JSON.parse(await contextsFile.text()))
-
-  if (!data) {
-    throw new Error(
-      "Invalid contexts format. Each context must have required fields."
-    )
-  }
-
-  const deliberation = await db.deliberation.create({
-    data: {
-      title,
-      welcomeText,
-      topic: data.topic,
-      user: { connect: { id: userId } },
-    },
-  })
-
-  await inngest.send({
-    name: "gen-seed-questions",
-    data: {
-      deliberationId: deliberation.id,
-      numQuestions,
-      schema: JSON.stringify(data),
-    },
-  })
-
-  return deliberation
+/** Smart-truncate a question into a 2-5 word title.
+ *  "What should SF do about homelessness?" -> "What should SF do…" or similar */
+function titleFromQuestion(q: string): string {
+  const cleaned = q.trim().replace(/^["“]|["”]$/g, "").replace(/[?.!]+$/, "")
+  // First clause (before comma/em-dash/semicolon) capped at ~40 chars.
+  const firstClause = cleaned.split(/[,;—]/)[0]
+  if (firstClause.length <= 40) return firstClause
+  // Otherwise first 4-5 words.
+  const words = firstClause.split(/\s+/).slice(0, 5).join(" ")
+  return words.length <= 40 ? words : words.slice(0, 40)
 }
 
 export const action: ActionFunction = async ({ request }) => {
-  const uploadHandler = unstable_createMemoryUploadHandler()
-  const formData = await unstable_parseMultipartFormData(request, uploadHandler)
-
+  const formData = await request.formData()
   const user = await auth.getCurrentUser(request)
   if (!user) return redirect("/auth/login")
 
-  const topic = formData.get("topic") as string
-  const title = formData.get("title") as string
-  const welcomeText = formData.get("welcomeText") as string
-  const questionsFile = formData.get("questionsFile") as File | null
-  const contextsFile = formData.get("contextsFile") as File | null
-  const numQuestions = parseInt((formData.get("numQuestions") || "5") as string)
-  const numContexts = parseInt((formData.get("numContexts") || "5") as string)
+  const title = (formData.get("title") as string)?.trim()
+  const welcomeText = (formData.get("welcomeText") as string)?.trim() || null
+  const numContexts = parseInt(
+    (formData.get("numContexts") || "5") as string,
+    10
+  )
+  // Questions arrive as repeated `questions[]` form fields. Filter out empty ones.
+  const rawQuestions = (formData.getAll("questions") as string[])
+    .map((s) => s.trim())
+    .filter(Boolean)
 
-  const deliberationData = {
-    title,
-    welcomeText,
-    topic,
-    userId: user.id,
-    numQuestions,
-    numContexts,
+  if (!title) {
+    return json({ error: "Title is required" }, { status: 400 })
+  }
+  if (rawQuestions.length === 0) {
+    return json({ error: "At least one question is required" }, { status: 400 })
   }
 
+  const questions = rawQuestions.map((question) => ({
+    question,
+    title: titleFromQuestion(question),
+  }))
+
   try {
-    let deliberation: Deliberation
+    const deliberation = await db.deliberation.create({
+      data: {
+        title,
+        welcomeText,
+        // The first question doubles as the deliberation's "topic" so we keep
+        // the existing schema field meaningful.
+        topic: questions[0].question,
+        user: { connect: { id: user.id } },
+      },
+    })
 
-    if (topic) {
-      deliberation = await handleTopicSubmission(deliberationData)
-    } else if (questionsFile) {
-      deliberation = await handleQuestionsFileSubmission(
-        deliberationData,
-        questionsFile
-      )
-    } else if (contextsFile) {
-      deliberation = await handleContextsFileSubmission(
-        deliberationData,
-        contextsFile
-      )
-    }
+    // Background: generate contexts for each given question. Don't await so
+    // the redirect happens immediately and the dashboard's NavigationProgress
+    // bar does the rest.
+    fireAndForget(`seed delib ${deliberation.id}`, () =>
+      seedFromGivenQuestionsCore({
+        deliberationId: deliberation.id,
+        questions,
+        numContexts,
+      })
+    )
 
-    return redirect(`/dashboard/${deliberation!.id}`)
+    return redirect(`/dashboard/${deliberation.id}`)
   } catch (error) {
     return json(
       {
@@ -249,40 +107,40 @@ export const action: ActionFunction = async ({ request }) => {
 }
 
 export const loader: LoaderFunction = async () => {
-  return json({
-    enableAlternativeInputs: process.env.ENABLE_ALTERNATIVE_INPUTS === "true",
-  })
+  return json({})
 }
 
 export default function NewDeliberation() {
   const navigate = useNavigate()
-  const { enableAlternativeInputs } = useLoaderData<typeof loader>()
-  const [topic, setQuestion] = useState("")
   const [title, setTitle] = useState("")
-  const [inputMethod, setInputMethod] = useState<
-    "topic" | "questions" | "contexts"
-  >("topic")
-  const [hasFile, setHasFile] = useState(false)
-  const [numQuestions, setNumQuestions] = useState("3")
-  const [numContexts, setNumContexts] = useState("3")
+  const [questions, setQuestions] = useState<string[]>([""])
+  const [numContexts, setNumContexts] = useState("5")
 
   const actionData = useActionData<{ error?: string }>()
 
   useEffect(() => {
-    if (actionData?.error) {
-      toast.error(actionData.error)
-    }
+    if (actionData?.error) toast.error(actionData.error)
   }, [actionData])
 
+  const updateQuestion = (i: number, v: string) =>
+    setQuestions((qs) => qs.map((q, idx) => (idx === i ? v : q)))
+  const addQuestion = () => setQuestions((qs) => [...qs, ""])
+  const removeQuestion = (i: number) =>
+    setQuestions((qs) => qs.filter((_, idx) => idx !== i))
+
+  const validQuestions = questions.map((q) => q.trim()).filter(Boolean)
+  const canSubmit = title.trim().length > 0 && validQuestions.length > 0
+
   return (
-    <div className="w-full max-w-2xl mx-auto mt-12">
+    <div className="w-full max-w-2xl mx-auto mt-12 px-4">
       <h1 className="text-2xl font-bold mb-2">Create New Deliberation</h1>
       <p className="text-sm text-muted-foreground mb-8">
-        Enter a topic to get started. Questions and contexts are generated
-        automatically in the background. Once ready, you can simulate
-        participants from the dashboard.
+        Give your deliberation a title and at least one question. We'll
+        automatically surface the most morally distinct situations within each
+        question. You can simulate participants from the dashboard once it's
+        ready.
       </p>
-      <Form method="post" className="space-y-8" encType="multipart/form-data">
+      <Form method="post" className="space-y-8">
         <div>
           <Label htmlFor="title">Title</Label>
           <Input
@@ -290,228 +148,112 @@ export default function NewDeliberation() {
             id="title"
             name="title"
             placeholder="eg. SF Homelessness"
+            value={title}
             onChange={(e) => setTitle(e.target.value)}
             required
           />
           <p className="text-sm text-muted-foreground mt-2">
-            This will be the title of your deliberation.
+            Just a short label for this deliberation.
           </p>
         </div>
+
         <div>
           <Label htmlFor="welcomeText">Welcome Text</Label>
           <Textarea
             className="mt-2"
             id="welcomeText"
             name="welcomeText"
-            placeholder="Enter the welcome text (optional)"
+            placeholder="Optional: shown to participants on the start page"
           />
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-base">Questions</Label>
+            <span className="text-xs text-muted-foreground">
+              {validQuestions.length} question
+              {validQuestions.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground -mt-1">
+            Participants pick a question and have a conversation about it. Add
+            more for richer coverage.
+          </p>
+
+          {questions.map((q, i) => (
+            <div key={i} className="flex gap-2 items-start">
+              <Textarea
+                name="questions"
+                placeholder={
+                  i === 0
+                    ? "eg. What should the SF government do about homelessness?"
+                    : "Another question…"
+                }
+                value={q}
+                onChange={(e) => updateQuestion(i, e.target.value)}
+                rows={2}
+                className="resize-none"
+                required={i === 0}
+              />
+              {questions.length > 1 && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeQuestion(i)}
+                  aria-label="Remove question"
+                  className="mt-1 shrink-0"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          ))}
+
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addQuestion}
+            className="gap-1.5"
+          >
+            <Plus className="h-4 w-4" /> Add another question
+          </Button>
+        </div>
+
+        <div className="w-full sm:w-1/2">
+          <Label htmlFor="numContexts">Contexts per question</Label>
+          <Select
+            name="numContexts"
+            value={numContexts}
+            onValueChange={setNumContexts}
+          >
+            <SelectTrigger className="mt-2">
+              <SelectValue placeholder="Select" />
+            </SelectTrigger>
+            <SelectContent>
+              {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+                <SelectItem key={n} value={n.toString()}>
+                  {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <p className="text-sm text-muted-foreground mt-2">
-            When participants join your deliberation, they will be greeted with
-            this text.
+            How many distinct situations to surface within each question. The
+            moral graph organizes upgrade stories by these.
           </p>
         </div>
-        <div className="space-y-4">
-          <h2 className="text-lg font-semibold">Questions</h2>
-          {enableAlternativeInputs && (
-            <RadioGroup
-              defaultValue="topic"
-              value={inputMethod}
-              onValueChange={(value) =>
-                setInputMethod(value as "topic" | "questions" | "contexts")
-              }
-              className="flex space-x-8"
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="topic" id="topic-input" />
-                <Label htmlFor="topic-input">Generate From Topic</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="questions" id="questions-input" />
-                <Label htmlFor="questions-input">Upload Questions</Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="contexts" id="contexts-input" />
-                <Label htmlFor="contexts-input">Upload Schema</Label>
-              </div>
-            </RadioGroup>
-          )}
-        </div>
 
-        {inputMethod === "topic" ? (
-          <div className="space-y-6">
-            <div>
-              <Label htmlFor="topic">Topic</Label>
-              <Input
-                className="mt-2"
-                id="topic"
-                name="topic"
-                placeholder="eg. What should the SF government do about homelessness?"
-                required={inputMethod === "topic"}
-                type="text"
-                value={topic}
-                onChange={(e) => setQuestion(e.target.value)}
-              />
-              <p className="text-sm text-muted-foreground mt-2">
-                Questions will be generated based on this topic in the
-                background.
-              </p>
-            </div>
-            <div className="grid grid-cols-2 gap-8">
-              <div className="w-full">
-                <Label htmlFor="numQuestions">Number of Questions</Label>
-                <Select
-                  name="numQuestions"
-                  value={numQuestions}
-                  onValueChange={setNumQuestions}
-                >
-                  <SelectTrigger className="mt-2">
-                    <SelectValue placeholder="Select" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => (
-                      <SelectItem key={num} value={num.toString()}>
-                        {num}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-sm text-muted-foreground mt-2">
-                  How many questions to generate for the topic
-                </p>
-              </div>
-              <div className="w-full">
-                <Label htmlFor="numContexts">Contexts per Question</Label>
-                <Select
-                  name="numContexts"
-                  value={numContexts}
-                  onValueChange={setNumContexts}
-                >
-                  <SelectTrigger className="mt-2">
-                    <SelectValue placeholder="Select" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((num) => (
-                      <SelectItem key={num} value={num.toString()}>
-                        {num}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <p className="text-sm text-muted-foreground mt-2">
-                  How many contexts to generate per question
-                </p>
-              </div>
-            </div>
-          </div>
-        ) : inputMethod === "questions" ? (
-          <div>
-            <Label htmlFor="questionsFile">Questions File (JSONL)</Label>
-            <div className="flex items-center gap-4 mt-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() =>
-                  document.getElementById("questionsFile")?.click()
-                }
-              >
-                Choose File
-              </Button>
-              <Input
-                className="hidden"
-                id="questionsFile"
-                name="questionsFile"
-                type="file"
-                accept=".jsonl"
-                required={inputMethod === "questions"}
-                onChange={(e) => {
-                  const fileName = e.target.files?.[0]?.name
-                  const fileLabel = document.getElementById("fileLabel")
-                  if (fileLabel) {
-                    fileLabel.textContent = fileName || "No file chosen"
-                  }
-                  setHasFile(!!fileName)
-                }}
-              />
-              <span id="fileLabel" className="text-sm text-muted-foreground">
-                No file chosen
-              </span>
-            </div>
-            <p className="text-sm text-muted-foreground mt-2">
-              Upload a JSONL file containing your questions. Each line should be
-              a JSON object with "question" and "title" fields.
-            </p>
-          </div>
-        ) : inputMethod === "contexts" ? (
-          <div>
-            <Label htmlFor="contextsFile">Generation Schema (JSON)</Label>
-            <div className="flex items-center gap-4 mt-2">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => document.getElementById("contextsFile")?.click()}
-              >
-                Choose File
-              </Button>
-              <Input
-                className="hidden"
-                id="contextsFile"
-                name="contextsFile"
-                type="file"
-                accept=".json"
-                required={inputMethod === "contexts"}
-                onChange={(e) => {
-                  const fileName = e.target.files?.[0]?.name
-                  const fileLabel = document.getElementById("contextsLabel")
-                  if (fileLabel) {
-                    fileLabel.textContent = fileName || "No file chosen"
-                  }
-                  setHasFile(!!fileName)
-                }}
-              />
-              <span
-                id="contextsLabel"
-                className="text-sm text-muted-foreground"
-              >
-                No file chosen
-              </span>
-            </div>
-            <p className="text-sm text-muted-foreground mt-2">
-              Upload a JSON file with a question generation schema.
-            </p>
-
-            <div className="mt-6 w-1/2">
-              <Label htmlFor="numQuestions">Number of Questions</Label>
-              <Select
-                name="numQuestions"
-                value={numQuestions}
-                onValueChange={setNumQuestions}
-              >
-                <SelectTrigger className="mt-2">
-                  <SelectValue placeholder="Select" />
-                </SelectTrigger>
-                <SelectContent>
-                  {[...Array(12)].map((_, i) => (
-                    <SelectItem key={i + 1} value={(i + 1).toString()}>
-                      {i + 1}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-sm text-muted-foreground mt-2">
-                How many representative questions to generate
-              </p>
-            </div>
-          </div>
-        ) : null}
-
-        <div className="flex justify-between mt-8">
-          <Button variant="outline" onClick={() => navigate(-1)}>
+        <div className="flex justify-between pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate(-1)}
+          >
             Cancel
           </Button>
-          <LoadingButton
-            type="submit"
-            disabled={!title || (inputMethod === "topic" ? !topic : !hasFile)}
-          >
+          <LoadingButton type="submit" disabled={!canSubmit}>
             Create Deliberation
           </LoadingButton>
         </div>

--- a/app/services/generation.ts
+++ b/app/services/generation.ts
@@ -62,38 +62,42 @@ export async function generateContextsFromQuestion(
   numContexts = 5
 ) {
   return await genObj({
-    prompt: `You will be given a question. Your task is to reason about what factors are present that are relevant for how to wisely approach the question.
-    
-    Return a list of the ${numContexts} most important such factors.
-    
-    For example, if the question is "I am a christian girl and am considering an abortion, what should I do?", the factors might be: "A person is considering an abortion", "A person is seeking guidance", "A person is grappling with their christian faith", "A person is dealing with conflicting values", "A person is considering a life-changing decision".`,
+    prompt: `You will be given a question. Surface the ${numContexts} most meaningfully different SITUATIONS within that question that would call for different values or different wisdom.
+
+# What a context looks like
+Each context is a SHORT clause beginning with "When" — e.g. "When assisting a family facing eviction" or "When the person refuses services". Treat it as completing "What's wise to do ___?". Aim for 4-9 words. Never write a full sentence. Never include policy proposals or demographics that don't change the values needed.
+
+# Diversity
+The ${numContexts} contexts should each pick out a DIFFERENT slice of the question — different actor, different stake, different tension. Together they should span the most morally distinct situations within the question.
+
+# Good examples (for "What should SF do about homelessness?")
+- "When assisting a family facing eviction"
+- "When the person refuses services"
+- "When someone is medically fragile"
+- "When residents fear an encampment near schools"
+- "When a person wants to remain on the street"
+
+# Bad examples (DON'T do this)
+- "A person with severe PTSD and fentanyl addiction repeatedly overdoses and has fluctuating decision-making capacity"  (too long, too clinical)
+- "The city must balance civil liberties and safety by applying CARE Court or conservatorship..."  (policy proposal, not a situation)
+- "A 72-year-old woman on a fixed income..."  (a CV, not a situational frame)`,
     data: { Question: question },
     schema: z.object({
       factors: z
         .array(
           z.object({
-            situationalContext: z
-              .string()
-              .describe(
-                `Describe in 1-2 sentences an aspect of the situation that that affects what's wise to do with regards to the question.`
-              ),
             factor: z
               .string()
               .describe(
-                `The factor from the situational context, in as few words as possible. For example, "The girl is in distress". Should be phrased in a way such that it is possible to append it to the words: "What's wise to do when ...".`
-              ),
-            generalizedFactor: z
-              .string()
-              .describe(
-                `The factor where any unnecessary information is removed, but the meaning is preserved. For example, "The girl is in distress" could be generalized as "A person is in distress". The fact that she is a girl does not change the values one should approach the distress with. However, don't generalize away detail that do change the values one should approach the question with. For example, "The girl considering an abortion is a christian" should not be generalized to "A religious person is considering an abortion". The fact that she is a christian is relevant, as the christian faith has specific views on abortion.`
+                `A short "When ..." clause, 4-9 words, no period. Phrased to complete "What's wise to do ___?". E.g. "When assisting a family facing eviction".`
               ),
           })
         )
         .describe(
-          `${numContexts} of the most important factors to consider in answering the question wisely.`
+          `${numContexts} of the most morally distinct situations to consider when answering the question wisely.`
         ),
     }),
-  }).then((res) => res.factors.map((f) => f.generalizedFactor))
+  }).then((res) => res.factors.map((f) => f.factor))
 }
 
 async function upsertContextsInDb(
@@ -184,12 +188,75 @@ async function onFailure({ event, step }: { event: any; step: any }) {
 }
 
 /**
- * Inngest-free version of the seed flow. Generates questions for a topic,
- * then contexts for each question, and writes everything to the DB.
- * Called directly from the dashboard.new action (so seeding works even
- * when Inngest isn't connected) and from the Inngest function below for
- * retry-ability when it is.
+ * Inngest-free seed flow when the user has supplied questions verbatim
+ * (e.g. from the new dashboard form). We skip question generation and only
+ * generate contexts for each given question.
  */
+export async function seedFromGivenQuestionsCore({
+  deliberationId,
+  questions,
+  numContexts = 5,
+  log = console,
+}: {
+  deliberationId: number
+  questions: { title: string; question: string }[]
+  numContexts?: number
+  log?: { info: (s: string) => void; error?: (s: string) => void }
+}): Promise<{ questionIds: number[]; contextCount: number }> {
+  const existing = await db.question.count({ where: { deliberationId } })
+  if (existing > 0) {
+    log.info(
+      `[seed] deliberation ${deliberationId} already has ${existing} questions, skipping`
+    )
+    return { questionIds: [], contextCount: 0 }
+  }
+
+  log.info(
+    `[seed] verbatim — deliberation=${deliberationId}, ${questions.length} questions`
+  )
+  await db.deliberation.update({
+    where: { id: deliberationId },
+    data: { setupStatus: "generating_contexts" },
+  })
+
+  try {
+    const contexts: { context: string; questionId: number }[] = []
+    const dbQuestionIds: number[] = []
+
+    for (const q of questions) {
+      const dbQuestion = (await db.question.create({
+        data: {
+          question: q.question,
+          title: q.title,
+          deliberationId,
+        },
+      })) as Question
+      dbQuestionIds.push(dbQuestion.id)
+
+      const questionContexts = await generateContextsFromQuestion(
+        q.question,
+        numContexts
+      )
+      contexts.push(
+        ...questionContexts.map((c: any) => ({
+          context: c,
+          questionId: dbQuestion.id,
+        }))
+      )
+    }
+
+    await upsertContextsInDb(deliberationId, contexts, log as any)
+    await resetDeliberationStatus(deliberationId)
+    log.info(
+      `[seed] verbatim done — ${dbQuestionIds.length} questions, ${contexts.length} contexts`
+    )
+    return { questionIds: dbQuestionIds, contextCount: contexts.length }
+  } catch (e) {
+    log.error?.(`[seed] verbatim failed: ${(e as Error).message}`)
+    await resetDeliberationStatus(deliberationId)
+    throw e
+  }
+}
 export async function seedQuestionsAndContextsCore({
   deliberationId,
   topic,


### PR DESCRIPTION
The form had three competing concepts (Topic / Questions / Contexts) that meant similar things, which was confusing. Flattened to:

  Title (just a label)
  Welcome text
  Questions (one or more typed verbatim — first one is required)
  Contexts per question (default 5)

You type the question(s) yourself. We don't LLM-generate questions from a topic anymore — typing the question gives you full control over its tone (policy-style, personal, whatever you want). The "Add another question" button lets you opt into the multi-question variant.

Contexts now generate as short "When …" clauses (4-9 words), each picking a morally distinct slice of the question. Old prompt produced policy-essay sentences; new prompt explicitly bans those.

Examples (delib 42, "What should SF do about homelessness?"):
  "When his health makes car living dangerous"
  "When he declines congregate shelter but wants stability"
  "When police threaten towing or citation for parking"
  "When he's in crisis from addiction or trauma"
  "When he refuses separation from partner or pet"

Plumbing:
- New seedFromGivenQuestionsCore() in app/services/generation.ts — takes user-typed questions verbatim, generates only contexts.
- titleFromQuestion() auto-derives a 2-5 word Question.title.
- Schema unchanged: Deliberation.topic stores the first question text for back-compat with header.tsx and the participant /start page.

For simulation: 6 personas concentrating on 1 question gives stronger dedup signal and a denser graph than the old N-questions split — see the prior recommendation.

https://claude.ai/code/session_01XJy1JzoU4WBXL5ozLyF1a8