### PR TITLE
Add dev-only login route for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,23 @@ For each multi-member cluster the discriminator returns `allEquivalent: true|fal
 
 To update the database schema, execute: `npx prisma db push`. The schema can be found [here](./schema.prisma).
 
+## Dev login (skip the email-code flow)
+
+`POST /auth/dev` lets you log in as any existing user without round-tripping a Mailgun login code. Gated by `SESSION_SECRET` (the same env var cowpunk-auth uses to sign cookies) and hard-disabled when `NODE_ENV=production` (returns 404).
+
+There's a small form at `GET /auth/dev` for manual use, or hit it from the shell:
+
+```bash
+# Log in as user id 1 and capture the session cookie
+curl -s -c /tmp/cookies.txt -X POST http://localhost:5173/auth/dev \
+  -d "secret=$SESSION_SECRET" -d "userId=1" -d "redirect=/"
+
+# Then any authed route works
+curl -s -b /tmp/cookies.txt http://localhost:5173/deliberation/33/start
+```
+
+Form fields: `secret` (required, must equal `process.env.SESSION_SECRET`), `userId` (defaults to `1`), `redirect` (defaults to `/`).
+
 ## Querying the database
 
 A small helper script `scripts/db.ts` runs read-only queries via Neon's HTTPS-based serverless driver. Useful in environments that block raw `5432/tcp` (CI sandboxes, edge runtimes, etc.):

--- a/app/routes/auth.dev.tsx
+++ b/app/routes/auth.dev.tsx
@@ -1,0 +1,86 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, redirect } from "@remix-run/node"
+import { Form, useSearchParams } from "@remix-run/react"
+import { auth, db } from "~/config.server"
+
+// Dev-only login. Posts a SESSION_SECRET; if it matches, sets session.userId
+// to the requested userId (default 1) so we can manually test routes that
+// require auth without going through the email-code flow.
+//
+// Disabled when NODE_ENV=production. Hard-fail rather than silently no-op so
+// it can never accidentally ship as a backdoor.
+function assertDev() {
+  if (process.env.NODE_ENV === "production") {
+    throw new Response("Not Found", { status: 404 })
+  }
+}
+
+export async function loader(_args: LoaderFunctionArgs) {
+  assertDev()
+  return null
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  assertDev()
+  const form = await request.formData()
+  const provided = String(form.get("secret") ?? "")
+  const userId = Number(form.get("userId") ?? 1)
+  const redirectTo = String(form.get("redirect") ?? "/")
+
+  const expected = process.env.SESSION_SECRET
+  if (!expected) throw new Response("SESSION_SECRET not set", { status: 500 })
+  if (provided !== expected) {
+    throw new Response("Bad secret", { status: 401 })
+  }
+
+  const user = await db.user.findUnique({ where: { id: userId } })
+  if (!user) throw new Response(`No user with id=${userId}`, { status: 404 })
+
+  const session = await auth.storage.getSession()
+  session.set("userId", user.id)
+  session.set("email", user.email)
+  session.set("roles", [...(user.role ?? [])])
+
+  return redirect(redirectTo, {
+    headers: {
+      "Set-Cookie": await auth.storage.commitSession(session),
+    },
+  })
+}
+
+export default function DevLogin() {
+  const [params] = useSearchParams()
+  const redirectTo = params.get("redirect") ?? "/"
+  return (
+    <div className="grid h-screen place-items-center p-8">
+      <Form method="post" className="flex flex-col gap-3 w-80">
+        <h1 className="text-xl font-semibold">Dev login</h1>
+        <p className="text-sm text-muted-foreground">
+          Logs you in as the given user id. Disabled in production.
+        </p>
+        <input type="hidden" name="redirect" value={redirectTo} />
+        <label className="text-sm">
+          User id
+          <input
+            name="userId"
+            defaultValue={1}
+            className="block w-full border rounded px-2 py-1 text-sm"
+          />
+        </label>
+        <label className="text-sm">
+          Session secret
+          <input
+            name="secret"
+            type="password"
+            className="block w-full border rounded px-2 py-1 text-sm"
+          />
+        </label>
+        <button
+          type="submit"
+          className="bg-black text-white rounded px-3 py-2 text-sm"
+        >
+          Log in
+        </button>
+      </Form>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
Added a development-only authentication route that allows manual testing of authenticated features without going through the email-code flow. This route is completely disabled in production and will return a 404 error.

## Key Changes
- Created new `app/routes/auth.dev.tsx` route with loader and action handlers
- Implements a simple form-based login that validates a `SESSION_SECRET` environment variable
- Allows specifying a user ID (defaults to 1) to log in as different users
- Supports redirecting to a specified URL after successful login
- Includes safety checks:
  - Hard-fails with 404 in production (never silently no-ops to prevent accidental backdoor)
  - Validates the provided secret matches `SESSION_SECRET`
  - Verifies the requested user exists in the database
- Provides a simple UI form for entering the session secret and user ID
- Sets session data (userId, email, roles) and commits the session cookie on successful authentication

## Implementation Details
- Uses Remix's `auth.storage` for session management
- Validates environment variables and user existence before creating session
- Redirects with proper Set-Cookie header to establish the authenticated session
- Form includes hidden redirect parameter to return user to their intended destination

https://claude.ai/code/session_01AFYZqE9xGjpYugjDTwEi5c