### PR TITLE
Pipeline robustness: idempotent context+canonical writes, tolerant KV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 node_modules
 node_modules.nosync
 
+# Project lockfile is bun.lock; ignore lockfiles from other package managers.
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
 /.cache
 /build
 /public/build

--- a/app/routes/api.chat-assistant.ts
+++ b/app/routes/api.chat-assistant.ts
@@ -31,8 +31,12 @@ export async function action({ request }: ActionFunctionArgs) {
 
   // Persist the articulated card via the canonical write path (DB upsert,
   // embedding, KV mirror, find-new-contexts Inngest event). The transcript
-  // we record is what the user has typed up to and including the turn that
-  // triggered the tool call.
+  // we record is the conversation up to the user's last turn PLUS a synthetic
+  // assistant tool_call + tool result for submit_values_card — `messages` is
+  // the inbound POST body and does not yet contain the assistant response
+  // we're streaming, so persisting it as-is would leave the saved transcript
+  // missing the tool call. Without that, reloading the chat thread doesn't
+  // re-render the values card and the "Continue" button stays hidden.
   const submitValuesCard = tool({
     description:
       "Submit the articulated values card once it has been jointly developed with the user.",
@@ -41,8 +45,31 @@ export async function action({ request }: ActionFunctionArgs) {
       description: z.string(),
       policies: z.array(z.string()),
     }),
-    execute: async (card) => {
-      const transcript: ChatMessage[] = uiMessagesToChatMessages(messages)
+    execute: async (card, { toolCallId }) => {
+      const baseTranscript = uiMessagesToChatMessages(messages)
+      const transcript: ChatMessage[] = [
+        ...baseTranscript,
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: toolCallId,
+              type: "function",
+              function: {
+                name: "submit_values_card",
+                arguments: JSON.stringify(card),
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: toolCallId,
+          name: "submit_values_card",
+          content: JSON.stringify({ ok: true }),
+        },
+      ]
       await persistArticulatedCard({
         authorId,
         threadId,

--- a/app/services/contexts.ts
+++ b/app/services/contexts.ts
@@ -107,37 +107,71 @@ export const findNewContexts = inngest.createFunction(
       Promise.all(contexts.map((c) => findDuplicateContext(deliberationId, c)))
     )
 
+    // Two LLM-generated contexts in this batch can resolve to the same target
+    // id (either identical strings, or different strings the dedupe step maps
+    // to the same existing context). Collapse before writing so concurrent
+    // upserts in Promise.all don't fight over the same primary key.
+    const seen = new Set<string>()
+    const writePlan: { isNew: boolean; targetId: string }[] = []
+    for (let i = 0; i < contexts.length; i++) {
+      const targetId = duplicates[i] ?? contexts[i]
+      if (seen.has(targetId)) continue
+      seen.add(targetId)
+      writePlan.push({ isNew: duplicates[i] === null, targetId })
+    }
+
     await step.run("Creating or linking contexts", async () =>
       Promise.all(
-        duplicates.map(async (duplicate, i) => {
-          if (!duplicate) {
+        writePlan.map(async ({ isNew, targetId }) => {
+          if (isNew) {
             // We're dealing with a new context! Create it, embed it, and link it to the question.
-            logger.info(`Creating new context: ${contexts[i]}`)
-            const context = await db.context.create({
-              data: {
-                id: contexts[i],
+            logger.info(`Creating new context: ${targetId}`)
+            // Concurrent find-new-contexts runs (one per chat) can race on the
+            // same generated context name; upsert keeps that idempotent.
+            const context = await db.context.upsert({
+              where: {
+                id_deliberationId: { id: targetId, deliberationId },
+              },
+              update: {},
+              create: {
+                id: targetId,
                 deliberationId,
                 createdInChatId: chatId,
-                ContextsForQuestions: {
-                  create: { questionId },
+              },
+            })
+            await db.contextsForQuestions.upsert({
+              where: {
+                contextId_questionId_deliberationId: {
+                  contextId: context.id,
+                  deliberationId,
+                  questionId,
                 },
+              },
+              update: {},
+              create: {
+                contextId: context.id,
+                deliberationId,
+                questionId,
               },
             })
             await embedContext(context.id)
           } else {
             // Duplicate context already exist in the deliberation! However, it could be from a different question. Link it to the current question (if not already linked).
-            logger.info(
-              `Linking context ${contexts[i]} to question ${questionId}`
-            )
-            await db.contextsForQuestions.update({
+            logger.info(`Linking context ${targetId} to question ${questionId}`)
+            await db.contextsForQuestions.upsert({
               where: {
                 contextId_questionId_deliberationId: {
-                  contextId: duplicate,
+                  contextId: targetId,
                   deliberationId,
                   questionId,
                 },
               },
-              data: { contextId: duplicate },
+              update: {},
+              create: {
+                contextId: targetId,
+                deliberationId,
+                questionId,
+              },
             })
           }
         })

--- a/app/services/deduplication.ts
+++ b/app/services/deduplication.ts
@@ -12,7 +12,20 @@ import { embedValue } from "values-tools"
 async function createCanonicalCard(
   valuesCard: ValuesCard
 ): Promise<CanonicalValuesCard> {
-  // Create a canonical values card.
+  // Schema has @@unique([title, description, policies]). The LLM judge in the
+  // similarity step can disagree with that constraint (different phrasing of
+  // the same value, or — more often — identical text after the seed-card dev
+  // helper or repeated runs). Find the existing row first to avoid a hard
+  // UniqueConstraintViolation that would fail the dedup step.
+  const existing = await db.canonicalValuesCard.findFirst({
+    where: {
+      deliberationId: valuesCard.deliberationId,
+      title: valuesCard.title,
+      description: valuesCard.description,
+      policies: { equals: valuesCard.policies },
+    },
+  })
+  if (existing) return existing as CanonicalValuesCard
   const canonical = await db.canonicalValuesCard.create({
     data: {
       title: valuesCard.title,

--- a/app/services/simulation.ts
+++ b/app/services/simulation.ts
@@ -84,8 +84,17 @@ async function writeProgress(
   deliberationId: number,
   patch: Partial<SimulationProgress> & { stage: SimulationStage; message: string }
 ) {
-  const existing = (await kv.get<SimulationProgress>(progressKey(deliberationId))) ?? {
-    stage: "starting" as const,
+  // KV is best-effort progress reporting only. If it's down or rate-limited,
+  // don't fail the whole Inngest step (which would otherwise retry the
+  // simulation and waste LLM credits).
+  let existing: SimulationProgress | null = null
+  try {
+    existing = (await kv.get<SimulationProgress>(progressKey(deliberationId))) ?? null
+  } catch (e) {
+    console.warn("KV get failed (non-fatal):", (e as Error).message)
+  }
+  const base: SimulationProgress = existing ?? {
+    stage: "starting",
     stageIndex: 0,
     stageCount: 5,
     personasTotal: 0,
@@ -97,12 +106,16 @@ async function writeProgress(
     runId: "",
   }
   const next: SimulationProgress = {
-    ...existing,
+    ...base,
     ...patch,
     stageIndex: STAGE_INDEX[patch.stage],
   }
   // 1h TTL so stale progress doesn't haunt later runs
-  await kv.set(progressKey(deliberationId), JSON.stringify(next), { ex: 3600 })
+  try {
+    await kv.set(progressKey(deliberationId), JSON.stringify(next), { ex: 3600 })
+  } catch (e) {
+    console.warn("KV set failed (non-fatal):", (e as Error).message)
+  }
   return next
 }
 


### PR DESCRIPTION
Three fixes surfaced by exercising the full deliberation -> dedup ->
hypothesize flow end-to-end against a fresh deliberation.

contexts.findNewContexts: the LLM-mined contexts are written through
Promise.all, so two batch entries that resolve to the same target id
would race on the same primary key. The "link to existing context"
branch also used update() and threw when no row existed yet for the
question. Collapse the write plan to a unique target set, then upsert
both the Context and the ContextsForQuestions row.

deduplication.createCanonicalCard: the LLM duplicate judge can return
"not equivalent" for two cards that share title+description+policies
(seed-card helper, or identical re-articulations across runs), which
trips the @@unique([title, description, policies]) constraint. Look up
an existing canonical with the same shape before inserting.

simulation.writeProgress: progress is reported through Vercel KV only.
If KV is down or rate-limited, every step.run wrapping a writeProgress
call would throw and Inngest would retry the entire simulation, burning
LLM credits. Treat KV as best-effort.

https://claude.ai/code/session_01Mee89Myo4c3tPqLPMMUhD6