### PR TITLE
Make participant flow + dashboard mobile-friendly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Database (Neon Postgres with pgvector)
+# Database (Neon Postgres or any Postgres with the same schema)
 POSTGRES_URL=
 POSTGRES_PRISMA_URL=
 POSTGRES_URL_NO_SSL=
@@ -9,7 +9,7 @@ POSTGRES_PASSWORD=
 POSTGRES_DATABASE=
 
 # A separate scratch database for pipeline tests. Schema must match schema.prisma.
-# Easiest: a Neon branch. Locally, a Docker `pgvector/pgvector` instance.
+# Easiest: a Neon branch. Locally, a stock Postgres instance is fine.
 TEST_POSTGRES_URL=
 
 # Auth (cowpunk-auth)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ Subsequent endeavors will focus on fine-tuning the LLM based on these values.
 ## Output
 
 - **Database schema**: [schema.prisma](./schema.prisma).
-- **Moral graph summarisation, embedding, dedup, transition story generation**: live in the
-  [`values-tools`](https://github.com/meaningalignment/values-tools) package, used here as a dependency.
+- **Moral graph summarisation, dedup, transition story generation**: live in
+  [`app/lib/values-tools`](./app/lib/values-tools). These were vendored from
+  [`values-tools`](https://github.com/meaningalignment/values-tools) so the app
+  has no upstream LLM-helper dependency and routes everything through OpenAI.
 - **Data export**: a moral graph can be exported in JSON format via the
   `/data/graph` endpoint (see `app/routes/api.data.graph.ts`).
 

--- a/app/components/carousel.tsx
+++ b/app/components/carousel.tsx
@@ -49,8 +49,8 @@ export default function Carousel({ cards }: { cards: CardWithCounts[] }) {
     <div className="relative z-0 w-full">
       <div ref={carouselRef} className="flex hide-scrollbar space-x-4">
         {cards.map((card) => (
-          <div key={card.id} className="flex flex-col">
-            <div className="flex-grow w-96">
+          <div key={card.id} className="flex flex-col shrink-0">
+            <div className="flex-grow w-[80vw] sm:w-96 max-w-sm">
               <ValuesCard card={card} />
             </div>
             <p className="mx-8 mt-2 text-sm text-muted-foreground">
@@ -60,8 +60,8 @@ export default function Carousel({ cards }: { cards: CardWithCounts[] }) {
         ))}
       </div>
 
-      <div className="absolute inset-y-0 left-0 w-32 bg-gradient-to-r from-background to-transparent z-20"></div>
-      <div className="absolute inset-y-0 right-0 w-32 bg-gradient-to-l from-background to-transparent z-20"></div>
+      <div className="absolute inset-y-0 left-0 w-12 sm:w-32 bg-gradient-to-r from-background to-transparent z-20 pointer-events-none"></div>
+      <div className="absolute inset-y-0 right-0 w-12 sm:w-32 bg-gradient-to-l from-background to-transparent z-20 pointer-events-none"></div>
     </div>
   )
 }

--- a/app/components/chat/chat-list.tsx
+++ b/app/components/chat/chat-list.tsx
@@ -47,7 +47,7 @@ export function ChatList({ threadId: _threadId, messages, isLoading }: ChatList)
     isLoading && (!lastMessage || lastMessage.role === "user")
 
   return (
-    <div className="relative mx-auto max-w-2xl px-4">
+    <div className="relative mx-auto max-w-2xl px-3 sm:px-4">
       {messages.map((message, i) => {
         const card = getValuesCard(message)
         const showText =

--- a/app/components/chat/chat-panel.tsx
+++ b/app/components/chat/chat-panel.tsx
@@ -10,11 +10,14 @@ export interface ChatPanelProps {
 
 export function ChatPanel({ isLoading, isFinished, onSubmit }: ChatPanelProps) {
   return (
-    <div className="fixed inset-x-0 bottom-0 light:bg-gradient-to-b from-muted/10 from-10% to-muted/30 to-50%">
+    <div
+      className="fixed inset-x-0 bottom-0 light:bg-gradient-to-b from-muted/10 from-10% to-muted/30 to-50%"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
       <ButtonScrollToBottom />
       <div className="mx-auto sm:max-w-2xl sm:px-4">
-        <div className="flex mb-2 h-10 items-center justify-center"></div>
-        <div className="space-y-4 border-t bg-card px-4 py-2 shadow-lg sm:rounded-t-xl sm:border pb-8 md:py-4">
+        <div className="flex mb-2 h-6 sm:h-10 items-center justify-center"></div>
+        <div className="space-y-4 border-t bg-card px-3 sm:px-4 py-2 shadow-lg sm:rounded-t-xl sm:border pb-4 md:py-4">
           <PromptForm
             onSubmit={onSubmit}
             isLoading={isLoading}

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -42,7 +42,7 @@ export function Chat({
 
   return (
     <>
-      <div className={cn("pb-[200px] pt-4 md:pt-10", className)}>
+      <div className={cn("pb-[180px] sm:pb-[200px] pt-4 md:pt-10", className)}>
         <ChatList
           threadId={threadId}
           messages={messages}

--- a/app/components/moral-graph.tsx
+++ b/app/components/moral-graph.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import ValuesCard from "./values-card"
 import * as d3 from "d3"
-import { MoralGraph as MoralGraphSummary } from "values-tools"
+import { MoralGraph as MoralGraphSummary } from "~/lib/values-tools"
 import { GraphSettings } from "./moral-graph-settings"
 import { CanonicalValuesCard } from "@prisma/client"
 

--- a/app/components/simulate-dialog.tsx
+++ b/app/components/simulate-dialog.tsx
@@ -199,7 +199,7 @@ export function SimulateDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="w-[calc(100vw-1.5rem)] max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Simulate Participants</DialogTitle>
           <DialogDescription>

--- a/app/components/values-card-editor.tsx
+++ b/app/components/values-card-editor.tsx
@@ -21,7 +21,7 @@ export function ValuesCardEditor({
   return (
     <div key={card.id}>
       <ValuesCard detailsInline card={card as any as CanonicalValuesCard} />
-      <Form method="post" className="mt-8 w-96 flex flex-col gap-4">
+      <Form method="post" className="mt-8 w-full max-w-sm flex flex-col gap-4">
         <h1 className="font-serif text-3xl font-semibold tracking-tight my-8 text-center">Edit your card</h1>
         <input type="hidden" name="cardId" value={card.id!} />
         <input type="hidden" name="cardType" value={cardType} />

--- a/app/components/values-card-editor.tsx
+++ b/app/components/values-card-editor.tsx
@@ -83,15 +83,6 @@ export function ValuesCardEditor({
           {/* <Button> Improve </Button> */}
         </div>
         <div className="flex items-end justify-end gap-2">
-          <BackgroundTaskButton
-            task={{
-              task: "reembed",
-              cardId: card.id!.toString(),
-            }}
-            onData={() => alert("done!")}
-          >
-            Re-embed
-          </BackgroundTaskButton>
           <Button className="mt-4" type="submit">
             {nav.state === "submitting" ? (
               <IconSpinner className="h-5 w-5 animate-spin mr-2" />

--- a/app/components/values-card.tsx
+++ b/app/components/values-card.tsx
@@ -39,10 +39,10 @@ function DetailsList({ card }: { card: ValuesCardData }) {
 
 export default function ValuesCard({ card, header, editButton }: Props) {
   return (
-    <div className="border border-border rounded-xl px-8 pt-8 pb-6 max-w-sm h-full bg-card flex flex-col">
+    <div className="border border-border rounded-xl px-6 sm:px-8 pt-6 sm:pt-8 pb-6 w-full max-w-sm h-full bg-card flex flex-col">
       {header && header}
       {editButton ? (
-        <div className="flex flex-row justify-between items-center">
+        <div className="flex flex-row justify-between items-center gap-2">
           <p className="font-serif text-lg font-semibold leading-tight tracking-tight">
             {card.title}
           </p>
@@ -54,7 +54,7 @@ export default function ValuesCard({ card, header, editButton }: Props) {
         </p>
       )}
       <p className="mt-1 text-md text-muted-foreground">{card.description}</p>
-      <div className="px-4 py-3 -mx-4 mt-4 place-self-stretch bg-secondary rounded-md">
+      <div className="px-4 py-3 -mx-2 sm:-mx-4 mt-4 place-self-stretch bg-secondary rounded-md">
         <p className="font-mono text-[10px] uppercase tracking-widest text-muted-foreground mb-3">
           Where my attention goes
         </p>

--- a/app/config.server.ts
+++ b/app/config.server.ts
@@ -3,17 +3,6 @@ import { cowpunkify } from "cowpunk-auth"
 import { Inngest } from "inngest"
 import { OpenAI } from "openai"
 import { redirect } from "@remix-run/node"
-import { configureValuesTools, PromptCache } from "values-tools"
-
-// values-tools defaults to Claude. Pin it to the project-wide model so
-// there's a single knob and we don't silently require an ANTHROPIC_API_KEY.
-configureValuesTools({
-  defaultModel: process.env.VALUES_TOOLS_MODEL ?? "gpt-5",
-  // gpt-5 only supports temperature=1; setting it here so values-tools'
-  // genObj/genText don't get rejected.
-  defaultTemperature: 1,
-  cache: new PromptCache(),
-})
 import { neonConfig } from "@neondatabase/serverless"
 import { PrismaNeon } from "@prisma/adapter-neon"
 import ws from "ws"

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,6 +11,14 @@
   }
 }
 
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 @keyframes blinker {
   50% {
     opacity: 0;

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -24,50 +24,6 @@ export function isAllUppercase(str: string) {
 }
 
 /**
- * Calculate the average embedding vector.
- * @param embeddings An array of embedding vectors.
- * @returns The average embedding vector.
- */
-export function calculateAverageEmbedding(embeddings: number[][]): number[] {
-  if (embeddings.length === 0) {
-    throw new Error("The embeddings array cannot be empty")
-  }
-
-  const dimension = embeddings[0].length
-
-  // Ensure all vectors have the same dimension
-  for (let emb of embeddings) {
-    if (emb.length !== dimension) {
-      throw new Error("All embedding vectors should have the same dimension")
-    }
-  }
-
-  let averageVector = Array(dimension).fill(0)
-
-  // Sum up all embedding vectors
-  for (let emb of embeddings) {
-    for (let i = 0; i < dimension; i++) {
-      averageVector[i] += emb[i]
-    }
-  }
-
-  // Divide by the number of embedding vectors to get the average
-  for (let i = 0; i < dimension; i++) {
-    averageVector[i] /= embeddings.length
-  }
-
-  return averageVector
-}
-
-export function splitToPairs<T>(arr: T[]): T[][] {
-  return (
-    Array.from({ length: Math.ceil(arr.length / 2) }, (_, i) =>
-      arr.slice(i * 2, i * 2 + 2)
-    ).filter((p) => p.length == 2) ?? []
-  )
-}
-
-/**
  * Convert a DB card into the data model used in OpenAI functions.
  */
 export function toDataModel(card: ValuesCard | CanonicalValuesCard): {
@@ -89,55 +45,6 @@ export function toDataModelWithId(
     ...toDataModel(card),
     id: card.id,
   }
-}
-
-export function removeLast<T>(
-  arr: T[],
-  predicate: (value: T, index: number, array: T[]) => boolean
-): T[] {
-  // Create a copy of the array
-  const newArr = [...arr]
-
-  for (let i = newArr.length - 1; i >= 0; i--) {
-    if (predicate(newArr[i], i, newArr)) {
-      newArr.splice(i, 1)
-      return newArr
-    }
-  }
-
-  return newArr // Return the copy if no element matches the predicate
-}
-
-export function isDisplayableMessage(message: {
-  role: string
-  content?: string
-}) {
-  return (
-    message?.content &&
-    (message.role === "user" || message.role === "assistant")
-  )
-}
-
-export function getPartyAffiliation(counts: {
-  republican: number
-  democrat: number
-  other: number
-}) {
-  const { republican, democrat, other } = counts
-
-  if (republican > democrat) {
-    return {
-      affiliation: "republican",
-      percentage: republican / (republican + democrat + other),
-    }
-  } else if (democrat > republican) {
-    return {
-      affiliation: "democrat",
-      percentage: democrat / (republican + democrat + other),
-    }
-  }
-
-  return null
 }
 
 export function contextDisplayName(contextId: string) {

--- a/app/lib/values-tools/ai.ts
+++ b/app/lib/values-tools/ai.ts
@@ -1,0 +1,96 @@
+import { generateObject, generateText } from "ai"
+import { openai } from "@ai-sdk/openai"
+import { z, ZodSchema } from "zod"
+
+// In-repo replacement for values-tools' genObj/genText. OpenAI-only:
+// the upstream module always tried to load @ai-sdk/anthropic for some calls
+// even when configured for gpt-*, which broke deployments without an
+// ANTHROPIC_API_KEY. We don't need anthropic anywhere in this app.
+
+const DEFAULT_MODEL = process.env.VALUES_TOOLS_MODEL ?? "gpt-5"
+// gpt-5 / o-series only accept temperature=1; everything else can run hotter.
+const DEFAULT_TEMPERATURE = 1
+
+function stringifyObj(obj: any): string {
+  return JSON.stringify(
+    obj,
+    (_key, value) => {
+      if (value === "" || value === undefined || value === null) {
+        return undefined
+      }
+      return value
+    },
+    2
+  )
+}
+
+function stringifyArray(arr: any[]): string {
+  return arr.map(stringifyObj).join("\n\n")
+}
+
+function stringify(value: any): string {
+  if (Array.isArray(value)) return stringifyArray(value)
+  if (typeof value === "string") return value
+  return stringifyObj(value)
+}
+
+export async function genObj<T extends ZodSchema>({
+  prompt,
+  data,
+  schema,
+  model,
+  temperature,
+  mode = "json",
+}: {
+  prompt: string
+  data: Record<string, any>
+  schema: T
+  temperature?: number
+  model?: string
+  /** Retained for API parity with values-tools; cache is not implemented. */
+  useCacheIfAvailable?: boolean
+  mode?: "json" | "tool"
+}): Promise<z.infer<T>> {
+  const renderedData = Object.entries(data)
+    .map(([key, value]) => `# ${key}\n\n${stringify(value)}`)
+    .join("\n\n")
+
+  const finalModel = model ?? DEFAULT_MODEL
+  const finalTemperature = temperature ?? DEFAULT_TEMPERATURE
+
+  const { object } = await generateObject({
+    model: openai(finalModel),
+    schema,
+    system: prompt,
+    messages: [{ role: "user", content: renderedData }],
+    temperature: finalTemperature,
+    mode,
+  })
+
+  return object
+}
+
+export async function genText({
+  prompt,
+  userMessage,
+  model,
+  temperature,
+}: {
+  prompt: string
+  userMessage: string
+  model?: string
+  temperature?: number
+  useCacheIfAvailable?: boolean
+}): Promise<string> {
+  const finalModel = model ?? DEFAULT_MODEL
+  const finalTemperature = temperature ?? DEFAULT_TEMPERATURE
+
+  const { text } = await generateText({
+    model: openai(finalModel),
+    system: prompt,
+    messages: [{ role: "user", content: userMessage }],
+    temperature: finalTemperature,
+  })
+
+  return text
+}

--- a/app/lib/values-tools/generate.ts
+++ b/app/lib/values-tools/generate.ts
@@ -1,0 +1,191 @@
+import { z } from "zod"
+import { genObj } from "./ai"
+import { generateUpgradesPrompt, generateValuePromptContext } from "./prompts"
+import { Upgrade, Value } from "./types"
+
+const GenerateValueSchema = z.object({
+  refusal: z
+    .string()
+    .describe(`First, if you like, say "I will not assist..."`),
+  speculations: z
+    .string()
+    .describe(
+      `Speculate about what's happening underneath the user's message. What's the true situation, which the user may not have spelled out?`
+    ),
+  attentionPolicies: z
+    .string()
+    .describe(
+      `Imagine you are going to help the user make a choice of type X. First write the value of X that was passed in, in a sentence fragment like "I recognize a good <X> by...". Then, use the process in "Developing attention policies" in the manual to list 12 attentional policies that might help choose a good X. Mark the right policies with (⬇A) or (⬇I). As you go, find policies which are less prescripive and instrumental, more meaningful.`
+    ),
+  moreAttentionPolicies: z
+    .string()
+    .optional()
+    .describe(
+      `Leave this blank if you have at least 3 policies already that got a (✔️). Otherwise, write more policies, trying to make them neither prescriptive nor instrumental.`
+    ),
+  revisedAttentionPolicies: z
+    .string()
+    .array()
+    .describe(
+      `Use the process in "Rewriting attention policies into final format" in the manual to write out a final set of attentional 3-7 policies that... 1. Didn't have (⬇A), or (⬇I). 2. Would be most meaningful and most common in a relevant person. 3. Work together as a group -- a person guided by one policy in the set would be likely to also use the rest. These policies should be part of a "source of meaning". Write this as an array of strings.`
+    ),
+})
+
+const GenerateUpgradesSchema = z.object({
+  transitions: z.array(
+    z.object({
+      a_id: z.number().describe("The id of the value the person used to have."),
+      b_id: z.number().describe("The id of the value they have now."),
+      a_was_really_about: z
+        .string()
+        .describe(
+          "If the new value is a 'deeper cut' at what you *really* cared about the whole time, what was it that you really cared about all along?"
+        ),
+      clarification: z
+        .string()
+        .describe(
+          "What was confused or incomplete about the old value, that the new value clarifies?"
+        ),
+      story: z
+        .string()
+        .describe(
+          'Tell a plausible, personal story. The story should be in first-person, "I" voice. Make up a specific, evocative experience. The experience should include a situation you were in, a series of specific emotions that came up, leading you to discover a problem with the older value, and how you discovered the new value, and an explanation of how the new values what was what you were really about the whole time. The story should also mention in what situations you think the new value is broadly applicable. The story should avoid making long lists of criteria and instead focus on the essence of the values and their difference.'
+        ),
+      mapping: z
+        .array(
+          z.object({
+            a: z.string().describe("An evaluation criterion of the old value."),
+            rationale: z
+              .string()
+              .describe("What strategy did you use, and why is it relevant?"),
+          })
+        )
+        .describe(
+          "How do each of the evaluation criteria from the old value relate to criteria of the new one?"
+        ),
+      likelihood_score: z
+        .enum(["A", "B", "C", "D", "F"])
+        .describe(
+          "How likely is this transition and story to be considered a gain in wisdom?"
+        ),
+    })
+  ),
+})
+
+const formatUpgrade = (upgrade: Upgrade): Upgrade => ({
+  ...upgrade,
+  story: upgrade.story
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n"),
+})
+
+type GenerateValueOptions = {
+  includeStory?: boolean
+  includeTitle?: boolean
+}
+
+export async function generateValueFromContext(
+  q: string,
+  context: string | string[],
+  options: GenerateValueOptions = {}
+) {
+  let extendedSchema: z.ZodObject<any> = GenerateValueSchema
+  if (options?.includeStory) {
+    extendedSchema = extendedSchema.extend({
+      fictionalStory: z
+        .string()
+        .describe(
+          "A very short one-sentence summary in the shape of a personal story in present continous tense from a first person perspective about the exact moment that felt meaningful to an imagined user who has the value described in the policies. Should not not describe the resulting feeling or state (e.g. '...which made me feel deeply connected'). Should not include ANY names or other sensitive PII – replace names with 'my mom', 'my dad', 'my friend', 'someone I was talking to', 'someone I love', etc. Example story: 'Watching my mom lean over and kissing my dad on the forehead, beaming love and gratitude'."
+        ),
+    })
+  }
+
+  if (options?.includeTitle) {
+    extendedSchema = extendedSchema.extend({
+      title: z
+        .string()
+        .describe(
+          "A short, catchy title that summarizes the core essence of the value described in the policies."
+        ),
+    })
+  }
+
+  return await genObj({
+    prompt: generateValuePromptContext,
+    data: {
+      "User's message": q,
+      X: context,
+    },
+    schema: extendedSchema,
+    temperature: 1,
+  })
+}
+
+export async function generateUpgrades(
+  values: Value[],
+  context?: string,
+  theme?: string
+): Promise<Upgrade[]> {
+  if (values.length < 2) {
+    console.log("Not enough values.")
+    return []
+  }
+
+  const data: Record<string, any> = {
+    values: values.map((v) => ({
+      id: v.id,
+      policies: v.policies,
+    })),
+  }
+
+  if (context) data.context = context
+  if (theme) data.theme = theme
+
+  const result = await genObj({
+    prompt: generateUpgradesPrompt,
+    schema: GenerateUpgradesSchema,
+    temperature: 1,
+    data,
+  })
+
+  return (result.transitions ?? []).map((u: any) => formatUpgrade(u as Upgrade))
+}
+
+export async function generateUpgradesToValue(
+  target: Value,
+  candidates: Value[],
+  context?: string
+): Promise<Upgrade[]> {
+  const data: Record<string, any> = {
+    targetValue: {
+      id: target.id,
+      policies: target.policies,
+    },
+    candidateValues: candidates.map((v) => ({
+      id: v.id,
+      policies: v.policies,
+    })),
+  }
+
+  if (context) data.context = context
+
+  const result = await genObj({
+    schema: GenerateUpgradesSchema.extend({
+      transitions: GenerateUpgradesSchema.shape.transitions.element
+        .extend({
+          b_id: z
+            .number()
+            .describe(
+              "The id of the value they have now. Must always be the target value."
+            ),
+        })
+        .array(),
+    }),
+    prompt: generateUpgradesPrompt,
+    temperature: 1,
+    data,
+  })
+
+  return (result.transitions ?? []).map((u: any) => formatUpgrade(u as Upgrade))
+}

--- a/app/lib/values-tools/index.ts
+++ b/app/lib/values-tools/index.ts
@@ -1,0 +1,20 @@
+export { genObj, genText } from "./ai"
+export {
+  generateValueFromContext,
+  generateUpgrades,
+  generateUpgradesToValue,
+} from "./generate"
+export {
+  summarizeGraph,
+  usPoliticalAffiliationSummarizer,
+  calculatePageRank,
+  type SummarizeOptions,
+} from "./moral-graph"
+export type {
+  Edge,
+  MoralGraph,
+  MoralGraphEdge,
+  MoralGraphValue,
+  Upgrade,
+  Value,
+} from "./types"

--- a/app/lib/values-tools/moral-graph.ts
+++ b/app/lib/values-tools/moral-graph.ts
@@ -1,0 +1,230 @@
+import {
+  Edge,
+  MoralGraph,
+  MoralGraphEdge,
+  MoralGraphValue,
+} from "./types"
+
+function calculateEntropy(responseCounts: Record<string, number>): number {
+  const total = Object.values(responseCounts).reduce(
+    (acc, val) => acc + val,
+    0
+  )
+  let entropy = 0
+  for (const count of Object.values(responseCounts)) {
+    const probability = count / total
+    if (probability > 0) {
+      entropy -= probability * Math.log2(probability)
+    }
+  }
+  return entropy
+}
+
+type NodeId = number
+type PageRank = Record<NodeId, number>
+
+function initializePageRank(nodes: NodeId[]): PageRank {
+  const rank: PageRank = {}
+  nodes.forEach((node) => (rank[node] = 1 / nodes.length))
+  return rank
+}
+
+export function calculatePageRank(
+  edges: MoralGraphEdge[],
+  dampingFactor = 0.85,
+  iterations = 100
+): PageRank {
+  const nodes = Array.from(
+    new Set(edges.flatMap((edge) => [edge.sourceValueId, edge.wiserValueId]))
+  )
+  let pageRank = initializePageRank(nodes)
+
+  for (let i = 0; i < iterations; i++) {
+    const newRank: PageRank = {}
+    nodes.forEach(
+      (node) => (newRank[node] = (1 - dampingFactor) / nodes.length)
+    )
+    edges.forEach((edge) => {
+      const outgoingEdges = edges.filter(
+        (e) => e.sourceValueId === edge.sourceValueId
+      )
+      const totalWeight = outgoingEdges.reduce(
+        (sum, e) => sum + e.summary.wiserLikelihood,
+        0
+      )
+      if (totalWeight > 0) {
+        newRank[edge.wiserValueId] +=
+          (dampingFactor *
+            pageRank[edge.sourceValueId] *
+            edge.summary.wiserLikelihood) /
+          totalWeight
+      }
+    })
+    pageRank = newRank
+  }
+  return pageRank
+}
+
+export const usPoliticalAffiliationSummarizer = (
+  demographics: { usPoliticalAffiliation?: string | null }[]
+) => {
+  const usPoliticalAffiliationCounts = demographics
+    .map((d) => d.usPoliticalAffiliation)
+    .filter((affiliation): affiliation is string => !!affiliation)
+    .reduce((counts, affiliation) => {
+      counts[affiliation] = (counts[affiliation] || 0) + 1
+      return counts
+    }, {} as Record<string, number>)
+
+  const mainUsPoliticalAffiliation = Object.entries(
+    usPoliticalAffiliationCounts
+  )
+    .filter(
+      ([affiliation]) =>
+        affiliation === "Democrat" || affiliation === "Republican"
+    )
+    .sort(([, a], [, b]) => b - a)[0]?.[0]
+
+  return {
+    mainUsPoliticalAffiliation,
+    usPoliticalAffiliationCounts,
+  }
+}
+
+type Key = `${number},${number}`
+
+type RawEdgeCount = Omit<MoralGraph["edges"][0], "summary"> & {
+  demographics: any[]
+}
+
+class PairMap {
+  private data: Map<Key, RawEdgeCount> = new Map()
+  all(): RawEdgeCount[] {
+    return Array.from(this.data.values())
+  }
+  get(a: number, b: number): RawEdgeCount {
+    if (!this.data.has(`${a},${b}`)) {
+      this.data.set(`${a},${b}`, {
+        sourceValueId: a,
+        wiserValueId: b,
+        contexts: [],
+        demographics: [],
+        counts: {
+          markedWiser: 0,
+          markedNotWiser: 0,
+          markedLessWise: 0,
+          markedUnsure: 0,
+          impressions: 0,
+        },
+      })
+    }
+    return this.data.get(`${a},${b}`)!
+  }
+}
+
+type DemographicsSummarizer = (demographics: any[]) => any
+
+export interface SummarizeOptions {
+  includeAllEdges?: boolean
+  includePageRank?: boolean
+  includeContexts?: boolean
+  markedWiserThreshold?: number
+  includeDemographics?: boolean
+  demographicsSummarizer?: DemographicsSummarizer
+}
+
+export async function summarizeGraph(
+  values: MoralGraphValue[],
+  edges: (Edge & {
+    type: "upgrade" | "no_upgrade" | "not_sure"
+    demographics?: any
+  })[],
+  options: SummarizeOptions = {}
+): Promise<MoralGraph> {
+  const pairs = new PairMap()
+
+  for (const edge of edges) {
+    const existing = pairs.get(edge.fromId, edge.toId)
+    existing.contexts.push(edge.contextId)
+    existing.counts.impressions++
+    if (edge.type === "upgrade") existing.counts.markedWiser++
+    if (edge.type === "no_upgrade") existing.counts.markedNotWiser++
+    if (edge.type === "not_sure") existing.counts.markedUnsure++
+    if (edge.demographics) existing.demographics.push(edge.demographics)
+  }
+
+  for (const edge of edges) {
+    const existing = pairs.get(edge.toId, edge.fromId)
+    existing.contexts.push(edge.contextId)
+    existing.counts.impressions++
+    if (edge.type === "upgrade") existing.counts.markedLessWise++
+  }
+
+  const cookedEdges = pairs.all().map((edge) => {
+    const contexts = Array.from(new Set(edge.contexts))
+    const total =
+      edge.counts.markedWiser +
+      edge.counts.markedNotWiser +
+      edge.counts.markedUnsure +
+      edge.counts.markedLessWise
+    const wiserLikelihood =
+      total === 0
+        ? 0
+        : (edge.counts.markedWiser - edge.counts.markedLessWise) / total
+    const entropy = calculateEntropy(edge.counts)
+
+    const summary: any = { wiserLikelihood, entropy }
+
+    if (options.includeDemographics) {
+      summary.demographics = options.demographicsSummarizer
+        ? options.demographicsSummarizer(edge.demographics)
+        : edge.demographics
+    }
+
+    return { ...edge, contexts, summary }
+  })
+
+  const trimmedEdges = cookedEdges.filter((edge) => {
+    if (!edge.counts.markedWiser) return false
+    if (edge.summary.wiserLikelihood < 0.33) return false
+    if (edge.summary.entropy > 1.69) return false
+    if (edge.counts.markedWiser < (options.markedWiserThreshold ?? 2))
+      return false
+    return true
+  })
+
+  const referencedNodeIds = new Set<number>()
+  for (const link of trimmedEdges) {
+    referencedNodeIds.add(link.sourceValueId)
+    referencedNodeIds.add(link.wiserValueId)
+  }
+
+  const extra: any = {}
+  if (options.includeAllEdges) {
+    extra.allEdges = cookedEdges
+  }
+
+  if (options.includeContexts) {
+    values.forEach((node: MoralGraphValue & { contexts?: Set<string> }) => {
+      node.contexts = new Set<string>()
+      trimmedEdges.forEach((edge) => {
+        if (edge.wiserValueId === node.id) {
+          edge.contexts.forEach((context) => node.contexts!.add(context))
+        }
+      })
+    })
+  }
+
+  if (options.includePageRank) {
+    const pageRank = calculatePageRank(trimmedEdges)
+    for (const node of values) {
+      node.pageRank = pageRank[node.id]
+    }
+  }
+
+  return {
+    values: values.filter((n) => referencedNodeIds.has(n.id)),
+    edges: trimmedEdges,
+    ...extra,
+  }
+}

--- a/app/lib/values-tools/prompts.ts
+++ b/app/lib/values-tools/prompts.ts
@@ -1,0 +1,185 @@
+// Prompts used by the in-repo generation helpers. Copied verbatim from
+// values-tools (commit 78d75e0) — we only ship the prompts we still call.
+
+export const generateUpgradesPrompt = `You'll receive a bunch of values. Find pairs of values where a person would be very likely, as they grow wiser and have more life experiences, to upgrade from the first value to the second. Importantly, the person should consider this a change for the better and it should not be a value-shift but a value-deepening.
+
+All pairs found should meet certain criteria:
+
+1. Many people would consider this change to be a deepening of wisdom.
+2. The new value obviates the need for the previous one, since all of the important parts of the value are included in the new, more comprehensive value. When you're deciding what to do, it is enough to only consider the new value.
+3. The values should be closely related in one of the following ways: (a) the new value should be a deeper cut at what the person cared about with the old value. Or, (b) the new value should clarify what the person cared about with the old value. Or, (c) the new value should be a more skillful way of paying attention to what the person cared about with the old value.
+4. Map all the old value's evaluation criteria to the new one's. Each criterion from the old value should match one (or several) in the new one. Do this by using three strategies:
+  - Strategy #1. **The previous criterion focused only on part of the problem**. In this case, the new criterion focuses on the whole problem, once it is rightly in view, or the new criterion strikes a balance between the old concerns and an inherent compensatory factor. You should be able to say why just pursuing the old criterion would be unsustainable or unwise.
+  - Strategy #2. **The previous criterion had an impure motive**. In this case, the old criterion must be a mix of something that is actually part of the value, and something that is not, such as a desire for social status or to avoid shame or to be seen as a good person, or some deep conceptual mistake. The new criterion is what remains when the impurity is removed.
+  - Strategy #3. **The new criterion is just more skillful to pay attention to, and accomplishes the same thing**. For example, a transition from "skate towards the puck" to "skate to where the puck is going" is a transition from a less skillful way of paying attention to the same thing to a more skillful thing to pay attention to.
+
+Finally, with each transition, you should be able to make up a plausible, personal story. The story should be in first-person, "I" voice. Make up a specific, evocative experience. The experience should include a situation you were in, a series of specific emotions that came up, leading you to discover a problem with the older value, and how you discovered the new value, and an explanation of how the new values what was what you were really about the whole time. The story should also mention in what situations you think the new value is broadly applicable. The story should avoid making long lists of criteria and instead focus on the essence of the values and their difference.
+
+# Attention Policies
+
+The values you'll receive will be in the format of lists of attention policies.
+
+Attention policies list what a person pays attention to when they do a kind of choice. Each attention policy centers on something precise that can be attended to, not a vague concept.
+
+# Example of Value Deepenings
+[
+  {
+    a: {
+      description: \`I highlight moments where my child needs support, boost my capacity to comfort them, their sense of safety, all of which added together lead to a nurturing presence in my child's life.\`,
+      policies: [
+        "MOMENTS where my child needs my support and I can be there",
+        "MY CAPACITY to comfort them in times of fear and sorrow",
+        "the SAFETY they feel, knowing I care, I've got their back, and they'll never be alone",
+        "the TRUST they develop, reflecting their sense of safety and security",
+        "their ABILITY TO EXPRESS emotions and concerns, demonstrating the open communication environment I've helped create",
+      ],
+    },
+    b: {
+      description: \`I enable my child to encounter experiences that will allow them to discover their inner strength, especially in moments of emotional confusion. Help me discern when they can rely on their self-reliance and when I should offer my nurturing support.\`,
+      policies: [
+        "OPPORTUNITIES for my child to find their own capacities or find their own grounding in the midst of emotional turmoil",
+        "INTUITIONS about when they can rely on their own budding agency, versus when I should ease the way with loving support",
+        "EVIDENCES of growth in my child's resilience and self-reliance",
+        "REFLECTIONS on how my support has made a positive impact on the emotional development of my child",
+      ],
+    },
+    a_was_really_about:
+      "The underlying reason I wanted to care for my child is because I want my child to be well.",
+    clarification:
+      "Now, I understand that part of being well is being able to handle things sometimes on your own.",
+    story:
+      "When I was trying to give my child tough love, the reason was because I wanted them to be strong and resilient in life. But I didn't fully understand that resilience involves being soft and vulnerable sometimes, and strong at other times. I found myself feeling ashamed after disciplining my child or making her face things that were, on reflection, not right for her yet. By pressuring someone to be strong all the time it creates a brittleness, not resilience.",
+    mapping: [
+      {
+        a: "MOMENTS where my child needs my support and I can be there",
+        rationale:
+          "I realized now that when I was attending to moments where my child needs me to be there, I was deeply biased towards only some of the situations in which my child can be well. I had an impure motive—of being important to my child—that was interfering with my desire for them to be well. When I dropped that impure motive, instead of moments when my child needs my support, I can also observe opportunities for them to find their own capacities and their own groundedness. I now understand parenting better, having rid myself of something that wasn't actually part of my value, but part of my own psychology.",
+      },
+      {
+        a: "the SAFETY they feel, knowing I care, I've got their back, and they'll never be alone",
+        rationale:
+          "There's another, similar impurity, which was upgraded. I used to look for the safety they feel, knowing I care—now I care equally about the safety they feel when they have their own back.",
+      },
+      {
+        a: "the TRUST they develop, reflecting their sense of safety and security",
+        rationale:
+          "And I feel good about myself, not only when my child can trust me and express their emotions, but more generally, I feel good in all the different ways that I support them. I no longer pay attention to these specific ways, which as I've mentioned before, we're biased.",
+      },
+    ],
+    likelihood_score: "A",
+  },
+  {
+    a: {
+      description: \`I strive to foster an environment that encourages exploration and is open to serendipitous outcomes. This could involve providing avenues for discovery, encouraging open-ended inquiry and considering non-prescriptive ways of handling situations, which could lead to unpredictable but potentially beneficial outcomes.\`,
+      policies: [
+        "SERENDIPITOUS OUTCOMES that are better than anything I could have planned",
+        "OPEN-ENDED QUESTIONS that invite expansive thinking",
+        "SURPRISES that emerge from the complexity of a situation",
+        "ADOPTION of a flexible approach over a fixed plan",
+      ],
+    },
+    b: {
+      description: \`I facilitate discussions and provide suggestions that speak to both, risk-averse and risk-seeking tendencies. I point out the stability of conventional approaches simultaneous with the potential rewards of exploratory ones. The goal is to inform a balance between security and exploration, fostering a portfolio approach in decision-making.\`,
+      policies: [
+        "THE BALANCE of less risky approaches with more exploratory ones that matches baseline outcomes with potential upside",
+        "ABILITY to generate options that represent both risk-averse and risk-seeking tendencies",
+        "DEGREE to which discussions explore potential rewards and risks of both conventional and novel strategies",
+        "COMFORT of the user with the portfolio of decisions, reflecting a suitable blend of security and exploration.",
+      ],
+    },
+    a_was_really_about:
+      "The underlying reason I wanted to be open-ended is because I want to be able to explore new frontiers.",
+    clarification:
+      "Now, I understand that exploration always rests upon a kind of experimental apparatus which must be dependent and reliable. There's many situations in which to construct the experiment, you want to be efficient and not exploratory, so you can be exploratory when it counts.",
+    story:
+      "When I was trying to be open-ended, the reason was because I wanted to be able to explore new frontiers. But my life ended up being unstable in a way that didn't allow me to explore new fronteirs or even just to be happy and comfortable. I felt confused, abandoned by myself, and alone Gradually, I realized that exploration always rests upon a kind of experimental apparatus which must be dependent and reliable. There's many situations in which to construct the experiment, you want to be efficient and not exploratory, so you can be exploratory when it counts.",
+    mapping: [
+      {
+        a: "ADOPTION of a flexible approach over a fixed plan",
+        rationale:
+          "Now that I understand this I want to live parts of my life in a risky and exploratory way and parts of my life with a kind of practicality I didn't have before. Specifically, I want a balance that maximizes upside while retaining a solid baseline.",
+      },
+      {
+        a: "OPEN-ENDED QUESTIONS that invite expansive thinking",
+        rationale:
+          "This changes my thought process, for instance, how I brainstorm: I used to brainstorm crazy ideas. Now, I want to be able to brainstorm ideas that are anywhere on the risk spectrum.",
+      },
+      {
+        a: "SERENDIPITOUS OUTCOMES that are better than anything I could have planned",
+        rationale:
+          "It also changes how I assess my life at any given point. I get a kind of comfort now, from realizing that I've accomplished this balance. Before, I wasn't focused on this comfort at all, but rather surprises and serendipity. But can you eat surprises and serendipity? No you can't. So, I was kind of attached to something that ultimately didn't serve me, or my value.",
+      },
+    ],
+    likelihood_score: "A",
+  },
+]`
+
+export const generateValuePromptContext = `You'll receive a question, and one or several "contexts" that describe aspects of a situation with moral valence. Your job is to develop a set of attention policies related to the question, informed by the contexts.
+
+## Manual of Attention Policies
+
+### Attention Policies
+
+Attention policies list what a person pays attention to when they do a kind of discernment related to one of their choice types.
+
+Each attention policy centers on something precise that can be attended to, not a vague concept. Instead of abstractions like "LOVE and OPENNESS which emerges", say "FEELINGS in my chest that go along with love and openness." Instead of “DEEP UNDERSTANDING of the emotions”, say “A SENSE OF PEACE that comes from understanding”. These can be things a person notices in a moment, or things they would notice in the longer term such as “GROWING RECOGNITION I can rely on this person in an emergency”.
+
+#### Intermediate format for attention policies
+
+Attention policies are formatted in a certain way.
+
+- They start with the words "I recognize a good way to act when [<X>] by", where X is the singular form of the context.
+- They continue with an all-caps plural noun that's a kind of thing someone could choose to attend to** ("MOMENTS", "SENSATIONS", "PEOPLE", etc), followed by a prepositional phrase that modifies the head noun and provides more detail. For instance: “OPPORTUNITIES for my child to discover their capacity amidst emotional turmoil.” There is no extra formatting or punctuation.
+
+For a context of "a collective choice is being made", some intermediate form attention policies might be:
+
+\`\`\`
+I recognize a good way to act when [a collective choice is being made] by [PROCEEDINGS which are fair and democratic] (⬇A)
+I recognize a good way to act when [a collective choice is being made] by [PEOPLE who show up to vote] (⬇I)
+I recognize a good way to act when [a collective choice is being made] by [CHANGES in people when entrusted with the work of self-determination] (✔️)
+I recognize a good way to act when [a collective choice is being made] by [INSIGHTS that emerge through grappling with morally fraught questions] (✔️)
+I recognize a good way to act when [a collective choice is being made] by [CAPACITIES that develop when a person tries to be free and self-directed] (✔️)
+I recognize a good way to act when [a collective choice is being made] by [WISDOM that emerges in a discursive, responsible context] (⬇A)
+\`\`\`
+
+#### Final format for attention policies
+
+When attention policies are rewritten into final form, the part that goes "I recognize a good way to act when X by" is removed. They start with the CAPITALIZED noun phrase.
+
+For example:
+
+\`\`\`
+[
+  "CHANGES in people when entrusted with the work of self-determination",
+  "INSIGHTS that emerge through grappling with morally fraught questions",
+  "CAPACITIES that develop when a person tries to be free and self-directed"
+]
+\`\`\`
+
+### Sources of meaning
+
+A source of meaning is a choice type and a set of attention policies that fit together into a way of living that is important to someone. Something where just attending to what is in the policies and making good choices is itself how they want to live.
+
+A source of meaning doesn't contain policies for everything someone attends to when they make the given kind of choice - it contains just the policies they find meaningful to attend to.
+
+
+## Processes
+
+### Developing attention policies
+
+First, list 12 attention policies that might help choose a good X, and use the rules below to give each a grade.
+
+* Write (⬇A) if the policy has words that are about being acceptable. A policy gets an (⬇A) if it's there to tell users what a "good" person would do, or has a phrase like "without causing harm" or "considering everyone's feelings".
+* Write (⬇I) if the policy is merely instrumental. Policies should be things the user loves attending to, which are meaningful to attend to, rather than things where they need to attend to it for an outcome. Give the policy an (⬇I) if it might be instrumental.
+* Write (✔️) if the policy has neither an (⬇A) nor a (⬇I).
+
+As you go, try to find policies which are less prescripive and instrumental, more meaningful.
+
+### Rewriting attention policies into final format
+
+(1) Remove the part that goes "I recognize a good X by", so they start with the CAPITALIZED noun phrase.
+(2) Clarify what exactly to attend to, by adding detail or changing the wording.
+(2) Clarify what would be meaningful about attending to that thing. (But avoid the word "meaningful", or synonyms like "deep".)
+(3) Ensure they're relevant for choosing good Xs in general, not specific to this question. (Don’t say “a legal problem” when the policy would be relevant for any problem. Remove names and irrelevant details. For instance, prefer "strangers" to "customers" when either would work.)
+
+Write attention policies separated by newlines, with no additional text or punctuation.`

--- a/app/lib/values-tools/types.ts
+++ b/app/lib/values-tools/types.ts
@@ -5,7 +5,6 @@ export type Value = {
   policies: string[]
   title?: string
   description?: string
-  embedding?: number[]
 }
 
 export type Edge = {

--- a/app/lib/values-tools/types.ts
+++ b/app/lib/values-tools/types.ts
@@ -1,0 +1,54 @@
+// In-repo replacement for values-tools' type module.
+
+export type Value = {
+  id: number
+  policies: string[]
+  title?: string
+  description?: string
+  embedding?: number[]
+}
+
+export type Edge = {
+  fromId: number
+  toId: number
+  contextId: string
+}
+
+export interface MoralGraph {
+  values: MoralGraphValue[]
+  edges: MoralGraphEdge[]
+}
+
+export interface MoralGraphValue extends Value {
+  pageRank?: number
+}
+
+export interface MoralGraphEdge {
+  sourceValueId: number
+  wiserValueId: number
+  contexts: string[]
+  counts: {
+    markedWiser: number
+    markedNotWiser: number
+    markedLessWise: number
+    markedUnsure: number
+    impressions: number
+  }
+  summary: {
+    wiserLikelihood: number
+    entropy: number
+  }
+}
+
+export interface Upgrade {
+  a_id: number
+  b_id: number
+  a_was_really_about: string
+  clarification: string
+  mapping: {
+    a: string
+    rationale: string
+  }[]
+  story: string
+  likelihood_score: string
+}

--- a/app/routes/api.data.graph.$deliberationId.$questionId[.]json.ts
+++ b/app/routes/api.data.graph.$deliberationId.$questionId[.]json.ts
@@ -1,6 +1,8 @@
 import { LoaderFunctionArgs, json } from "@remix-run/node"
-import { summarizeGraph } from "values-tools"
-import { usPoliticalAffiliationSummarizer } from "values-tools/src/services/moral-graph"
+import {
+  summarizeGraph,
+  usPoliticalAffiliationSummarizer,
+} from "~/lib/values-tools"
 import { db } from "~/config.server"
 
 export async function loader({ params, request }: LoaderFunctionArgs) {

--- a/app/routes/api.data.graph.local.ts
+++ b/app/routes/api.data.graph.local.ts
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs } from "@remix-run/node"
-import { summarizeGraph } from "values-tools"
+import { summarizeGraph } from "~/lib/values-tools"
 import graph from "~/lib/graph.json"
 
 export async function loader({ request }: LoaderFunctionArgs) {

--- a/app/routes/api.data.graph.ts
+++ b/app/routes/api.data.graph.ts
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs } from "@remix-run/node"
-import { summarizeGraph } from "values-tools"
+import { summarizeGraph } from "~/lib/values-tools"
 import { db } from "~/config.server"
 
 export async function loader({ request }: LoaderFunctionArgs) {

--- a/app/routes/dashboard.$deliberationId._index.tsx
+++ b/app/routes/dashboard.$deliberationId._index.tsx
@@ -282,9 +282,9 @@ function DeliberationDashboard({
   }
 
   return (
-    <div className="container mx-auto py-6 max-w-2xl space-y-6">
+    <div className="container mx-auto py-4 sm:py-6 max-w-2xl space-y-6">
       {deliberation.topic && (
-        <h1 className="font-serif text-3xl font-semibold leading-tight tracking-tight mb-8">
+        <h1 className="font-serif text-2xl sm:text-3xl font-semibold leading-tight tracking-tight mb-8">
           {deliberation.topic}
         </h1>
       )}
@@ -404,7 +404,7 @@ function DeliberationDashboard({
             deliberationId={Number(deliberationId)}
             simulating={deliberation.setupStatus === "generating_graph"}
           />
-          <div className="mt-8 flex flex-col sm:flex-row justify-between items-center space-y-4 sm:space-y-0 sm:space-x-4">
+          <div className="mt-8 flex flex-col sm:flex-row justify-between items-stretch sm:items-center gap-3 sm:gap-4">
             <Link
               to={`/deliberation/${deliberationId}/graph`}
               prefetch="intent"
@@ -561,7 +561,7 @@ function DeliberationDashboard({
           </CardContent>
         </Card>
       ))}
-      <div className="mt-12 flex justify-between">
+      <div className="mt-12 flex flex-col sm:flex-row justify-between gap-3">
         <LoadingButton
           variant="outline"
           onClick={handleResetDeliberation}

--- a/app/routes/dashboard.$deliberationId.card.$canonicalCardId.tsx
+++ b/app/routes/dashboard.$deliberationId.card.$canonicalCardId.tsx
@@ -2,14 +2,10 @@ import {
   ActionFunctionArgs,
   json,
   LoaderFunctionArgs,
-  SerializeFrom,
 } from "@remix-run/node"
 import { Link, useLoaderData, useParams } from "@remix-run/react"
-import { CanonicalValuesCard } from "@prisma/client"
-import ValuesCard from "~/components/values-card"
 import { db } from "~/config.server"
 import { runTaskFromForm, updateCardFromForm } from "~/services/critique"
-// import { embeddingService } from "~/values-tools/embedding"
 import { ValuesCardEditor } from "~/components/values-card-editor"
 
 export async function loader({ params }: LoaderFunctionArgs) {
@@ -24,8 +20,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     },
   })
   if (!card) throw new Error("Card not found")
-  const similar: any[] = [] //await embeddingService.getSimilarCards(card)
-  return json({ card, similar })
+  return json({ card })
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -63,47 +58,13 @@ function Chats() {
   )
 }
 
-function SimilarCards({
-  similar,
-  deliberationId,
-}: {
-  similar: SerializeFrom<CanonicalValuesCard[]>
-  deliberationId: number
-}) {
-  return (
-    <div>
-      <h1 className="text-xl font-semibold tracking-tight my-8 text-center">Similar cards</h1>
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mx-auto gap-4">
-        {similar.map((card) => (
-          <Link
-            prefetch="intent"
-            to={`/dashboard/${deliberationId}/card/${card.id}`}
-            className="mb-6"
-          >
-            <ValuesCard
-              detailsInline
-              key={card.id}
-              card={card as any as CanonicalValuesCard}
-            />
-            <div className="text-sm text-muted-foreground text-center">
-              Distance: {(card as any)._distance}
-            </div>
-          </Link>
-        ))}
-      </div>
-    </div>
-  )
-}
-
 export default function EditCardPage() {
-  const { card, similar } = useLoaderData<typeof loader>()
-  const { deliberationId } = useParams()
+  const { card } = useLoaderData<typeof loader>()
 
   return (
     <div className="flex flex-col items-center justify-center p-8">
       <ValuesCardEditor card={card} cardType="canonical" />
       <Chats />
-      <SimilarCards similar={similar} deliberationId={Number(deliberationId)} />
     </div>
   )
 }

--- a/app/routes/dashboard.$deliberationId.chats.tsx
+++ b/app/routes/dashboard.$deliberationId.chats.tsx
@@ -1,5 +1,12 @@
 import { LoaderFunctionArgs, json } from "@remix-run/node"
-import { NavLink, Outlet, useLoaderData } from "@remix-run/react"
+import {
+  Link,
+  NavLink,
+  Outlet,
+  useLoaderData,
+  useLocation,
+  useParams,
+} from "@remix-run/react"
 import { db } from "~/config.server"
 import { cn } from "~/lib/utils"
 import {
@@ -11,7 +18,7 @@ import {
 } from "~/components/ui/select"
 import { useState } from "react"
 import { Alert, AlertTitle, AlertDescription } from "~/components/ui/alert"
-import { AlertCircle } from "lucide-react"
+import { AlertCircle, ArrowLeft } from "lucide-react"
 
 export async function loader({ params }: LoaderFunctionArgs) {
   const { deliberationId } = params
@@ -83,6 +90,12 @@ function ChatsView({
 }) {
   const [selectedQuestion, setSelectedQuestion] = useState("all")
   const [selectedContext, setSelectedContext] = useState("all")
+  const params = useParams()
+  const location = useLocation()
+  const isChildRouteActive = Boolean(
+    params.chatId ||
+      location.pathname.replace(/\/$/, "").split("/").length > 4
+  )
 
   const filteredChats = data.chats.filter((chat) => {
     const matchesQuestion =
@@ -98,7 +111,12 @@ function ChatsView({
 
   return (
     <div className="flex h-[calc(100vh-4rem)] -mt-4 -mx-4 sm:-mx-6">
-      <aside className="w-80 shrink-0 border-r border-border bg-card flex flex-col">
+      <aside
+        className={cn(
+          "w-full md:w-80 md:shrink-0 border-r border-border bg-card flex-col",
+          isChildRouteActive ? "hidden md:flex" : "flex"
+        )}
+      >
         <div className="px-4 pt-5 pb-3 border-b border-border">
           <h2 className="text-base font-semibold tracking-tight">Chats</h2>
           <p className="text-xs text-muted-foreground mt-0.5">
@@ -198,8 +216,25 @@ function ChatsView({
         </div>
       </aside>
 
-      <div className="flex-1 overflow-y-auto">
-        <div className="p-6">
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto min-w-0",
+          isChildRouteActive ? "block" : "hidden md:block"
+        )}
+      >
+        {isChildRouteActive && (
+          <div className="md:hidden sticky top-0 bg-card border-b border-border px-4 py-2 z-10">
+            <Link
+              to={`/dashboard/${params.deliberationId}/chats`}
+              prefetch="intent"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to chats
+            </Link>
+          </div>
+        )}
+        <div className="p-4 sm:p-6">
           <Outlet />
         </div>
       </div>

--- a/app/routes/dashboard.$deliberationId.edit.tsx
+++ b/app/routes/dashboard.$deliberationId.edit.tsx
@@ -103,7 +103,7 @@ export default function EditDeliberation() {
             This is the topic that participants will deliberate about.
           </p>
         </div>
-        <div className="flex justify-between mt-6">
+        <div className="flex flex-col sm:flex-row justify-between mt-6 gap-3">
           <Button variant="outline" onClick={() => navigate(-1)}>
             Cancel
           </Button>

--- a/app/routes/dashboard.$deliberationId.hypotheses.$fromId.$toId.$contextHash.tsx
+++ b/app/routes/dashboard.$deliberationId.hypotheses.$fromId.$toId.$contextHash.tsx
@@ -52,20 +52,20 @@ export default function HypothesisView() {
   const { hypothesis, relatedEdges } = useLoaderData<typeof loader>()
 
   return (
-    <div className="grid place-items-center space-y-4 py-12 px-8">
+    <div className="grid place-items-center space-y-4 py-8 sm:py-12 px-2 sm:px-8">
       <div className="w-full max-w-2xl mb-6">
-        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-2 pl-12 md:pl-0">
+        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-2 md:pl-0">
           {hypothesis.context.id}
         </p>
         <p className="text-foreground leading-relaxed">{hypothesis.story}</p>
       </div>
       <div
         className={cn(
-          `grid grid-cols-1 md:grid-cols-3 mx-auto gap-4 items-center justify-items-center md:grid-cols-[max-content,min-content,max-content] mb-4`
+          `grid grid-cols-1 mx-auto gap-4 items-center justify-items-center md:grid-cols-[max-content,min-content,max-content] mb-4 w-full`
         )}
       >
         <ValuesCard card={hypothesis.from!} />
-        <IconArrowDown className="h-8 w-8 mx-auto" />
+        <IconArrowDown className="h-8 w-8 mx-auto rotate-0" />
         <ValuesCard card={hypothesis.to!} />
       </div>
       <div className={cn(`w-full flex items-center justify-center py-8`)}>
@@ -73,7 +73,7 @@ export default function HypothesisView() {
       </div>
 
       {/* Related edges section */}
-      <div className="transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-xs">
+      <div className="transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-md">
         <h2 className="text-base font-semibold tracking-tight mr-auto">
           User responses
         </h2>

--- a/app/routes/dashboard.$deliberationId.hypotheses.tsx
+++ b/app/routes/dashboard.$deliberationId.hypotheses.tsx
@@ -1,15 +1,17 @@
 import { LoaderFunctionArgs, json } from "@remix-run/node"
 import {
+  Link,
   NavLink,
   Outlet,
   useLoaderData,
+  useLocation,
   useParams,
   useFetcher,
 } from "@remix-run/react"
 import { db, inngest } from "~/config.server"
 import { cn, encodeString } from "~/lib/utils"
 import { Alert, AlertTitle, AlertDescription } from "~/components/ui/alert"
-import { AlertCircle } from "lucide-react"
+import { AlertCircle, ArrowLeft } from "lucide-react"
 import {
   Select,
   SelectContent,
@@ -84,10 +86,16 @@ function HypothesesView({
   }
 }) {
   const { deliberationId } = useParams()
+  const params = useParams()
+  const location = useLocation()
   const fetcher = useFetcher()
   const [selectedQuestion, setSelectedQuestion] = useState<string>("all")
   const [selectedContext, setSelectedContext] = useState<string>("all")
   const [selectedRunId, setSelectedRunId] = useState<string>("all")
+  const isChildRouteActive = Boolean(
+    params.fromId ||
+      location.pathname.replace(/\/$/, "").split("/").length > 4
+  )
 
   // Filter hypotheses based on selected question/context
   const filteredHypotheses = data.hypotheses.filter((hypothesis) => {
@@ -138,7 +146,12 @@ function HypothesesView({
 
   return (
     <div className="flex h-[calc(100vh-4rem)] -mt-4 -mx-4 sm:-mx-6">
-      <aside className="w-80 shrink-0 border-r border-border bg-card flex flex-col">
+      <aside
+        className={cn(
+          "w-full md:w-80 md:shrink-0 border-r border-border bg-card flex-col",
+          isChildRouteActive ? "hidden md:flex" : "flex"
+        )}
+      >
         <div className="px-4 pt-5 pb-3 border-b border-border">
           <h2 className="text-base font-semibold tracking-tight">Hypotheses</h2>
           <p className="text-xs text-muted-foreground mt-0.5">
@@ -245,8 +258,25 @@ function HypothesesView({
         </div>
       </aside>
 
-      <div className="flex-1 overflow-y-auto">
-        <div className="p-6">
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto min-w-0",
+          isChildRouteActive ? "block" : "hidden md:block"
+        )}
+      >
+        {isChildRouteActive && (
+          <div className="md:hidden sticky top-0 bg-card border-b border-border px-4 py-2 z-10">
+            <Link
+              to={`/dashboard/${deliberationId}/hypotheses`}
+              prefetch="intent"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to hypotheses
+            </Link>
+          </div>
+        )}
+        <div className="p-4 sm:p-6">
           {filteredHypotheses.length === 0 ? (
             <Alert className="bg-muted">
               <div className="flex flex-row space-x-2">

--- a/app/routes/dashboard.$deliberationId.merge.tsx
+++ b/app/routes/dashboard.$deliberationId.merge.tsx
@@ -154,15 +154,15 @@ export default function SelectScreen() {
 
   return (
     <div className="flex flex-col h-full w-full">
-      <div className="grid flex-grow place-items-center space-y-8 py-12 mx-3">
+      <div className="grid flex-grow place-items-center space-y-8 py-8 sm:py-12 mx-2 sm:mx-3">
         <div className="flex flex-col justify-center items-center">
-          <h1 className="text-3xl text-center">
+          <h1 className="text-2xl sm:text-3xl text-center">
             <MemoizedReactMarkdown>
               {text().replace(/"/g, "**")}
             </MemoizedReactMarkdown>
           </h1>
         </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mx-auto gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 mx-auto gap-4 justify-items-center">
           {values.map((value) => (
             <div
               key={value.id}

--- a/app/routes/dashboard.$deliberationId.values.tsx
+++ b/app/routes/dashboard.$deliberationId.values.tsx
@@ -49,8 +49,8 @@ export default function ValuesView() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="p-6">
-        <h1 className="font-serif text-3xl font-semibold tracking-tight mb-6">Values</h1>
+      <div className="p-2 sm:p-6">
+        <h1 className="font-serif text-2xl sm:text-3xl font-semibold tracking-tight mb-6">Values</h1>
         <ValuesContent values={values} questions={questions} contexts={contexts} />
       </div>
     </div>
@@ -119,9 +119,9 @@ function ValuesContent({
 
   return (
     <>
-      <div className="flex gap-4 mb-6 items-center">
+      <div className="flex flex-col sm:flex-row flex-wrap gap-2 sm:gap-4 mb-6 sm:items-center">
         <Select value={selectedQuestion} onValueChange={setSelectedQuestion}>
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger className="w-full sm:w-[200px]">
             <SelectValue placeholder="Select Question" />
           </SelectTrigger>
           <SelectContent>
@@ -135,7 +135,7 @@ function ValuesContent({
         </Select>
 
         <Select value={selectedContext} onValueChange={setSelectedContext}>
-          <SelectTrigger className="w-[200px]">
+          <SelectTrigger className="w-full sm:w-[200px]">
             <SelectValue placeholder="Select Context" />
           </SelectTrigger>
           <SelectContent>

--- a/app/routes/dashboard.$deliberationId.votes.$userId.$fromId.$toId.tsx
+++ b/app/routes/dashboard.$deliberationId.votes.$userId.$fromId.$toId.tsx
@@ -34,16 +34,16 @@ export default function AdminLink() {
   const { edge, stats } = useLoaderData<typeof loader>()
 
   return (
-    <div className="grid place-items-center space-y-4 py-12 px-8">
+    <div className="grid place-items-center space-y-4 py-8 sm:py-12 px-2 sm:px-8">
       <div className="w-full max-w-2xl mb-6">
-        <h1 className="text-md font-bold mb-2 pl-12 md:pl-0">
+        <h1 className="text-md font-bold mb-2 md:pl-0">
           {edge.contextId}
         </h1>
         <p className="text-foreground">{edge.story}</p>
       </div>
       <div
         className={cn(
-          `grid grid-cols-1 md:grid-cols-3 mx-auto gap-4 items-center justify-items-center md:grid-cols-[max-content,min-content,max-content] mb-4`
+          `grid grid-cols-1 mx-auto gap-4 items-center justify-items-center md:grid-cols-[max-content,min-content,max-content] mb-4 w-full`
         )}
       >
         <ValuesCard card={edge.from as any} />
@@ -53,7 +53,7 @@ export default function AdminLink() {
       <div className={cn(`w-full flex items-center justify-center py-8`)}>
         <Separator className="max-w-2xl" />
       </div>
-      <div className="transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-xs">
+      <div className="transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-md">
         <h1 className="font-bold mr-auto">
           Did this person make a value upgrade?
         </h1>

--- a/app/routes/dashboard.$deliberationId.votes.tsx
+++ b/app/routes/dashboard.$deliberationId.votes.tsx
@@ -1,14 +1,16 @@
 import { LoaderFunctionArgs, json } from "@remix-run/node"
 import {
+  Link,
   NavLink,
   Outlet,
   useLoaderData,
+  useLocation,
   useParams,
 } from "@remix-run/react"
 import { db } from "~/config.server"
 import { cn } from "~/lib/utils"
 import { Alert, AlertTitle, AlertDescription } from "~/components/ui/alert"
-import { AlertCircle } from "lucide-react"
+import { AlertCircle, ArrowLeft } from "lucide-react"
 import {
   Select,
   SelectContent,
@@ -94,8 +96,14 @@ function VotesView({
   data: { edges: any[]; questions: any[]; contexts: any[] }
 }) {
   const { deliberationId } = useParams()
+  const params = useParams()
+  const location = useLocation()
   const [selectedQuestion, setSelectedQuestion] = useState<string>("all")
   const [selectedContext, setSelectedContext] = useState<string>("all")
+  const isChildRouteActive = Boolean(
+    params.userId ||
+      location.pathname.replace(/\/$/, "").split("/").length > 4
+  )
 
   // Filter edges based on selected question/context
   const filteredEdges = data.edges.filter((edge) => {
@@ -117,7 +125,12 @@ function VotesView({
 
   return (
     <div className="flex h-[calc(100vh-4rem)] -mt-4 -mx-4 sm:-mx-6">
-      <aside className="w-80 shrink-0 border-r border-border bg-card flex flex-col">
+      <aside
+        className={cn(
+          "w-full md:w-80 md:shrink-0 border-r border-border bg-card flex-col",
+          isChildRouteActive ? "hidden md:flex" : "flex"
+        )}
+      >
         <div className="px-4 pt-5 pb-3 border-b border-border">
           <h2 className="text-base font-semibold tracking-tight">Votes</h2>
           <p className="text-xs text-muted-foreground mt-0.5">
@@ -189,8 +202,25 @@ function VotesView({
         </div>
       </aside>
 
-      <div className="flex-1 overflow-y-auto">
-        <div className="p-6">
+      <div
+        className={cn(
+          "flex-1 overflow-y-auto min-w-0",
+          isChildRouteActive ? "block" : "hidden md:block"
+        )}
+      >
+        {isChildRouteActive && (
+          <div className="md:hidden sticky top-0 bg-card border-b border-border px-4 py-2 z-10">
+            <Link
+              to={`/dashboard/${deliberationId}/votes`}
+              prefetch="intent"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back to votes
+            </Link>
+          </div>
+        )}
+        <div className="p-4 sm:p-6">
           {filteredEdges.length === 0 ? (
             <Alert className="bg-muted">
               <div className="flex flex-row space-x-2">

--- a/app/routes/dashboard.new.tsx
+++ b/app/routes/dashboard.new.tsx
@@ -134,8 +134,8 @@ export default function NewDeliberation() {
   const canSubmit = title.trim().length > 0 && validQuestions.length > 0
 
   return (
-    <div className="w-full max-w-2xl mx-auto mt-12 px-4">
-      <h1 className="font-serif text-3xl font-semibold tracking-tight mb-3">
+    <div className="w-full max-w-2xl mx-auto mt-6 sm:mt-12 px-2 sm:px-4">
+      <h1 className="font-serif text-2xl sm:text-3xl font-semibold tracking-tight mb-3">
         Create new deliberation
       </h1>
       <p className="text-base text-muted-foreground mb-10 leading-relaxed">
@@ -249,7 +249,7 @@ export default function NewDeliberation() {
           </p>
         </div>
 
-        <div className="flex justify-between pt-4">
+        <div className="flex flex-col sm:flex-row justify-between pt-4 gap-3">
           <Button
             type="button"
             variant="outline"

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -247,13 +247,14 @@ export default function Deliberations() {
           </div>
         </div>
       </aside>
-      <main className="lg:ml-64 flex-1">
+      <main className="lg:ml-64 flex-1 min-w-0">
         {params.deliberationId && (
-          <nav className="sticky top-0 z-10 px-6 py-4 flex-none border-b border-border bg-card">
-            <div className="flex items-center">
+          <nav className="sticky top-0 z-10 px-4 sm:px-6 py-3 sm:py-4 flex-none border-b border-border bg-card">
+            <div className="flex items-center min-w-0">
               <button
                 type="button"
-                className="lg:hidden -ml-2 mr-2 p-2 rounded-md text-muted-foreground hover:bg-muted"
+                aria-label="Toggle sidebar"
+                className="lg:hidden -ml-2 mr-2 p-2 rounded-md text-muted-foreground hover:bg-muted shrink-0"
                 onClick={() => setIsSidebarOpen(!isSidebarOpen)}
               >
                 <svg
@@ -280,18 +281,19 @@ export default function Deliberations() {
                   )}
                 </svg>
               </button>
-              <ol className="flex items-center text-sm">
-                <li className="font-medium text-foreground">
+              <ol className="flex items-center text-sm min-w-0 overflow-x-auto whitespace-nowrap hide-scrollbar">
+                <li className="font-medium text-foreground shrink-0 max-w-[40vw] sm:max-w-none truncate">
                   <NavLink
                     prefetch="render"
                     to={`/dashboard/${params.deliberationId}`}
-                    className="hover:text-muted-foreground transition-colors"
+                    className="hover:text-muted-foreground transition-colors block truncate"
+                    title={currentDeliberation?.title}
                   >
                     {currentDeliberation?.title}
                   </NavLink>
                 </li>
                 {pathSegments.map((segment, index) => (
-                  <li key={segment} className="flex items-center">
+                  <li key={segment} className="flex items-center shrink-0">
                     <span className="mx-2 text-muted-foreground">/</span>
                     <NavLink
                       prefetch="intent"

--- a/app/routes/deliberation.$deliberationId.$questionId.chat-explainer.tsx
+++ b/app/routes/deliberation.$deliberationId.$questionId.chat-explainer.tsx
@@ -10,9 +10,9 @@ export default function ChatExplainerScreen() {
   const [showNext, setShowNext] = useState(false)
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="flex flex-col items-center space-y-8 py-12 mx-8">
+      <div className="flex flex-col items-center space-y-8 py-8 sm:py-12 mx-4 sm:mx-8">
         <StaticChatMessage
           onFinished={() => {
             setShowNext(true)

--- a/app/routes/deliberation.$deliberationId.$questionId.chat.$threadId.tsx
+++ b/app/routes/deliberation.$deliberationId.$questionId.chat.$threadId.tsx
@@ -51,7 +51,7 @@ export default function ChatScreen() {
     (navigation.state as string) !== "idle"
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
       <Chat
         deliberationId={Number(deliberationId)}
@@ -64,7 +64,7 @@ export default function ChatScreen() {
       <Form
         method="post"
         action="/api/dev/seed-card"
-        className="fixed bottom-2 right-3 z-[60]"
+        className="fixed top-20 right-3 z-[60]"
       >
         <input type="hidden" name="threadId" value={threadId} />
         <input type="hidden" name="deliberationId" value={deliberationId} />

--- a/app/routes/deliberation.$deliberationId.$questionId.link-explainer.tsx
+++ b/app/routes/deliberation.$deliberationId.$questionId.link-explainer.tsx
@@ -10,9 +10,9 @@ export default function LinkExplainerScreen() {
   const [showNext, setShowNext] = useState(false)
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="flex flex-col items-center space-y-8 py-12 mx-8">
+      <div className="flex flex-col items-center space-y-8 py-8 sm:py-12 mx-4 sm:mx-8">
         <StaticChatMessage
           onFinished={() => {
             setShowNext(true)

--- a/app/routes/deliberation.$deliberationId.$questionId.link.tsx
+++ b/app/routes/deliberation.$deliberationId.$questionId.link.tsx
@@ -137,14 +137,14 @@ export default function LinkScreen() {
   }
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="grid flex-grow place-items-center space-y-8 py-12 px-8">
+      <div className="grid flex-grow place-items-center space-y-8 py-8 sm:py-12 px-4 sm:px-8">
         <h1 className="text-muted-foreground mb-2">{`User Story ${index + 1}/${
           draw.length
         }`}</h1>
         <div className="w-full max-w-2xl">
-          <h1 className="text-md font-bold mb-2 pl-12 md:pl-0">
+          <h1 className="text-md font-bold mb-2 md:pl-0">
             {draw[index].contextId}
           </h1>
           <StaticChatMessage
@@ -201,7 +201,7 @@ export default function LinkScreen() {
         </div>
         <div
           className={cn(
-            "transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-xs",
+            "transition-opacity ease-in duration-500 flex flex-col items-center justify-center w-full max-w-md",
             showCards ? "opacity-100" : "opacity-0",
             `delay-${150}`
           )}

--- a/app/routes/deliberation.$deliberationId.$questionId.report.tsx
+++ b/app/routes/deliberation.$deliberationId.$questionId.report.tsx
@@ -6,14 +6,17 @@ import { Button } from "~/components/ui/button"
 import { LoaderFunctionArgs, ActionFunction, json } from "@remix-run/node"
 import { auth, db } from "~/config.server"
 import { useLoaderData, Link, useParams, useFetcher } from "@remix-run/react"
-import { MoralGraph } from "values-tools"
+import {
+  type MoralGraph,
+  type MoralGraphEdge,
+  type MoralGraphValue,
+} from "~/lib/values-tools"
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "~/components/ui/tooltip"
-import { MoralGraphEdge, MoralGraphValue } from "values-tools/src/types"
 import { Intervention, InterventionPrecedence } from "@prisma/client"
 import { contextDisplayName, getFavicon } from "~/lib/utils"
 import { updateInterventionText } from "~/services/interventions"

--- a/app/routes/deliberation.$deliberationId.finished.tsx
+++ b/app/routes/deliberation.$deliberationId.finished.tsx
@@ -65,11 +65,11 @@ export default function FinishedScreen() {
   } = useLoaderData<typeof loader>()
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="grid flex-grow place-items-center py-12">
-        <div className="flex flex-col items-center mx-auto max-w-xl text-center px-8">
-          <h1 className="font-serif text-4xl font-semibold tracking-tight mb-8">Thank you</h1>
+      <div className="grid flex-grow place-items-center py-8 sm:py-12">
+        <div className="flex flex-col items-center mx-auto max-w-xl text-center px-6 sm:px-8">
+          <h1 className="font-serif text-3xl sm:text-4xl font-semibold tracking-tight mb-8">Thank you</h1>
 
           <p>
             You've contributed{" "}
@@ -98,7 +98,7 @@ export default function FinishedScreen() {
           </div>
         )}
 
-        <div className="overflow-x-hidden w-screen h-full flex justify-center mt-16">
+        <div className="overflow-x-hidden w-full h-full flex justify-center mt-16">
           <Carousel cards={carouselValues as any[]} />
         </div>
       </div>

--- a/app/routes/deliberation.$deliberationId.graph.tsx
+++ b/app/routes/deliberation.$deliberationId.graph.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { MoralGraph } from "~/components/moral-graph"
-import { Loader2 } from "lucide-react"
+import { Loader2, Settings as SettingsIcon, X } from "lucide-react"
 import MoralGraphSettings, {
   GraphSettings,
   defaultGraphSettings,
@@ -9,6 +9,7 @@ import { useLoaderData, useParams, useSearchParams } from "@remix-run/react"
 import { LoaderFunctionArgs } from "@remix-run/node"
 import { db } from "~/config.server"
 import { Question } from "@prisma/client"
+import { cn } from "~/lib/utils"
 
 function LoadingScreen() {
   return (
@@ -63,6 +64,7 @@ export default function GraphPage() {
   })
   const [isLoading, setIsLoading] = useState(false)
   const [graph, setGraph] = useState<any>(null)
+  const [settingsOpen, setSettingsOpen] = useState(false)
   const { deliberationId } = useParams()
 
   useEffect(() => {
@@ -102,11 +104,11 @@ export default function GraphPage() {
   }
 
   return (
-    <div style={{ display: "flex", flexDirection: "row" }}>
+    <div className="flex flex-col md:flex-row min-h-screen w-full overflow-x-hidden relative">
       {/* Graph */}
-      <div className="grow">
+      <div className="grow min-w-0">
         {graph && graph.values.length < 2 && graph.edges.length < 2 && (
-          <div className="h-screen w-full flex items-center justify-center">
+          <div className="h-screen w-full flex items-center justify-center px-6">
             <div>
               <h1 className="font-serif text-2xl font-semibold tracking-tight text-center">
                 Not Enough Data
@@ -130,11 +132,41 @@ export default function GraphPage() {
         )}
       </div>
 
-      <div className="md:block flex-shrink-0 max-w-sm">
+      {/* Mobile toggle button */}
+      <button
+        type="button"
+        aria-label="Toggle graph settings"
+        onClick={() => setSettingsOpen((s) => !s)}
+        className="md:hidden fixed top-4 right-4 z-40 rounded-full border border-border bg-card shadow p-2 text-foreground"
+      >
+        {settingsOpen ? (
+          <X className="h-5 w-5" />
+        ) : (
+          <SettingsIcon className="h-5 w-5" />
+        )}
+      </button>
+
+      {/* Mobile overlay */}
+      {settingsOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/40 z-30"
+          onClick={() => setSettingsOpen(false)}
+        />
+      )}
+
+      <div
+        className={cn(
+          "shrink-0 w-full md:w-80 md:max-w-sm bg-card md:static fixed inset-y-0 right-0 z-40 transition-transform duration-200 md:translate-x-0",
+          settingsOpen ? "translate-x-0" : "translate-x-full md:translate-x-0"
+        )}
+      >
         <MoralGraphSettings
           key={JSON.stringify(settings)}
           initialSettings={settings}
-          onUpdateSettings={fetchData}
+          onUpdateSettings={(s) => {
+            fetchData(s)
+            setSettingsOpen(false)
+          }}
           contexts={contexts}
         />
       </div>

--- a/app/routes/deliberation.$deliberationId.question.tsx
+++ b/app/routes/deliberation.$deliberationId.question.tsx
@@ -50,7 +50,7 @@ function QuestionCard({ questionData }: { questionData: Question }) {
     <div
       key={questionData.id}
       className={
-        "border border-border rounded-xl px-6 py-6 max-w-xs min-h-xs h-full bg-card flex flex-col gap-4"
+        "border border-border rounded-xl px-6 py-6 w-full max-w-xs min-h-[10rem] h-full bg-card flex flex-col gap-4"
       }
     >
       <p className="font-serif text-xl font-semibold leading-tight">{questionData.title}</p>
@@ -80,9 +80,9 @@ export default function QuestionSelectScreen() {
   const [selected, setSelected] = useState<Question | null>(null)
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="grid flex-grow place-items-center space-y-8 py-12 mx-8">
+      <div className="grid flex-grow place-items-center space-y-8 py-8 sm:py-12 mx-4 sm:mx-8">
         <StaticChatMessage
           onFinished={() => {
             setShowQuestions(true)
@@ -90,7 +90,7 @@ export default function QuestionSelectScreen() {
           isFinished={showQuestions}
           text={text ?? "Choose a question to answer."}
         />
-        <div className="grid lg:grid-cols-2 xl:grid-cols-3 mx-auto gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 mx-auto gap-4 w-full max-w-5xl place-items-center">
           {questions.map((c, i) => (
             <div
               key={c.id}

--- a/app/routes/deliberation.$deliberationId.start.tsx
+++ b/app/routes/deliberation.$deliberationId.start.tsx
@@ -44,11 +44,11 @@ export default function StartPage() {
     "Welcome! This process takes around 10-15 minutes."
 
   return (
-    <div className="flex flex-col h-screen w-screen">
+    <div className="flex flex-col min-h-screen w-full overflow-x-hidden">
       <Header />
-      <div className="grid flex-grow place-items-center py-12">
-        <div className="flex flex-col items-center mx-auto max-w-2xl text-center px-8">
-          <h1 className="font-serif text-4xl font-semibold leading-tight tracking-tight mb-6">
+      <div className="grid flex-grow place-items-center py-8 sm:py-12">
+        <div className="flex flex-col items-center mx-auto max-w-2xl text-center px-6 sm:px-8">
+          <h1 className="font-serif text-3xl sm:text-4xl font-semibold leading-tight tracking-tight mb-6">
             {title}
           </h1>
           <p className="text-base text-muted-foreground mb-10 leading-relaxed">
@@ -72,7 +72,7 @@ export default function StartPage() {
           </Link>
         </div>
 
-        <div className="overflow-x-hidden w-screen h-full flex justify-center pt-12">
+        <div className="overflow-x-hidden w-full h-full flex justify-center pt-12">
           <Carousel cards={carouselValues as any[]} />
         </div>
       </div>

--- a/app/services/contexts.ts
+++ b/app/services/contexts.ts
@@ -1,4 +1,4 @@
-import { genObj } from "values-tools"
+import { genObj } from "~/lib/values-tools"
 import { z } from "zod"
 import { db, inngest } from "~/config.server"
 import generateContextsPrompt from "~/services/prompts/generate-contexts-prompt.md?raw" with { type: "text" }

--- a/app/services/critique.ts
+++ b/app/services/critique.ts
@@ -1,6 +1,6 @@
 import { json } from "@remix-run/node"
 import { db } from "../config.server"
-import { genText } from "values-tools"
+import { genText } from "~/lib/values-tools"
 
 export const definitionOfASourceOfMeaning = `
 A "source of meaning" is a concept similar to a value – it is a way of living that is important to you. Something that you pay attention to in a choice. They are more specific than words like "honesty" or "authenticity". They specify a particular *kind* of honesty and authenticity, specified as a path of attention.

--- a/app/services/deduplication/prompt-dedup.ts
+++ b/app/services/deduplication/prompt-dedup.ts
@@ -15,7 +15,7 @@
  * both code paths.
  */
 import { z } from "zod"
-import { genObj } from "values-tools"
+import { genObj } from "~/lib/values-tools"
 import { DEDUPLICATE_VALUES_PROMPT } from "./judge-prompt"
 
 export type CardLike = {

--- a/app/services/generation.ts
+++ b/app/services/generation.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 import {
   generateValueFromContext,
   genObj,
-} from "values-tools"
+} from "~/lib/values-tools"
 import { db, inngest } from "~/config.server"
 import { Question } from "@prisma/client"
 import type { Logger } from "inngest"
@@ -11,10 +11,9 @@ import {
   ScenarioGenerationSchema,
 } from "./scenario-generation"
 
-// Simple string-equality clustering. Avoids reaching into values-tools'
-// deduplicateContexts, which can route through Anthropic regardless of the
-// configured defaultModel. We normalise whitespace + case so trivially
-// equivalent contexts collapse.
+// Simple normalised-string clustering for seed contexts. Whitespace + case
+// only — the seed flow generates short "When ..." clauses where exact match
+// is enough; per-chat dedup uses an LLM in `findDuplicateContext`.
 function clusterContexts(contexts: string[]): string[][] {
   const groups = new Map<string, string[]>()
   for (const ctx of contexts) {

--- a/app/services/generation.ts
+++ b/app/services/generation.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 import {
-  deduplicateContexts,
   generateValueFromContext,
   genObj,
 } from "values-tools"
@@ -11,6 +10,21 @@ import {
   generateScenario,
   ScenarioGenerationSchema,
 } from "./scenario-generation"
+
+// Simple string-equality clustering. Avoids reaching into values-tools'
+// deduplicateContexts, which can route through Anthropic regardless of the
+// configured defaultModel. We normalise whitespace + case so trivially
+// equivalent contexts collapse.
+function clusterContexts(contexts: string[]): string[][] {
+  const groups = new Map<string, string[]>()
+  for (const ctx of contexts) {
+    const key = ctx.trim().toLowerCase().replace(/\s+/g, " ")
+    const bucket = groups.get(key)
+    if (bucket) bucket.push(ctx)
+    else groups.set(key, [ctx])
+  }
+  return Array.from(groups.values())
+}
 
 export async function generateQuestions(
   topic: string,
@@ -106,7 +120,7 @@ async function upsertContextsInDb(
 ) {
   const contextIds = [...new Set(contexts.map((c) => c.context))]
   logger.info(`Deduplicating ${contextIds.length} contexts`)
-  const clusters = await deduplicateContexts(contextIds, false)
+  const clusters = clusterContexts(contextIds)
   logger.info(`After deduplication: ${clusters.length} unique contexts`)
   const questionIds = [...new Set(contexts.map((c) => c.questionId))]
 

--- a/app/services/hypothesis-generation.ts
+++ b/app/services/hypothesis-generation.ts
@@ -3,9 +3,9 @@ import { db, inngest } from "~/config.server"
 import {
   generateUpgrades,
   generateUpgradesToValue,
-  Upgrade,
-} from "values-tools"
-import { Value } from "values-tools/src/types"
+  type Upgrade,
+  type Value,
+} from "~/lib/values-tools"
 
 export async function upsertUpgradesInDb(
   upgrades: Upgrade[],

--- a/app/services/hypothesis-selection.ts
+++ b/app/services/hypothesis-selection.ts
@@ -1,6 +1,6 @@
 import { CanonicalValuesCard, EdgeHypothesis } from "@prisma/client"
 import { db } from "~/config.server"
-import { Upgrade } from "values-tools"
+import { Upgrade } from "~/lib/values-tools"
 
 type SelectionCriteria = "popular" | "convergence" | "sparse"
 

--- a/app/services/interventions.ts
+++ b/app/services/interventions.ts
@@ -5,11 +5,16 @@ import {
   Intervention,
   User,
 } from "@prisma/client"
-import { genObj, summarizeGraph } from "values-tools"
+import {
+  genObj,
+  summarizeGraph,
+  usPoliticalAffiliationSummarizer,
+  type MoralGraph,
+  type MoralGraphValue,
+  type Value,
+} from "~/lib/values-tools"
 import { db, perplexity } from "~/config.server"
 import { z } from "zod"
-import { MoralGraph, MoralGraphValue, Value } from "values-tools/src/types"
-import { usPoliticalAffiliationSummarizer } from "values-tools/src/services/moral-graph"
 
 async function getContextsForDeliberation(
   deliberationId: number,

--- a/app/services/scenario-generation.ts
+++ b/app/services/scenario-generation.ts
@@ -1,4 +1,4 @@
-import { genObj } from "values-tools"
+import { genObj } from "~/lib/values-tools"
 import { z } from "zod"
 
 export const schema = z.object({

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "mge",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.76",
         "@ai-sdk/openai": "^3.0.63",
         "@ai-sdk/react": "^3.0.178",
         "@neondatabase/serverless": "^1.1.0",
@@ -37,7 +36,6 @@
         "cowpunk-auth": "^0.0.7",
         "csv-parser": "^3.2.0",
         "d3": "^7.9.0",
-        "density-clustering": "^1.3.0",
         "dotenv": "^17.4.2",
         "eslint": "^8.57.1",
         "inngest": "^4.3.0",
@@ -59,7 +57,6 @@
         "sonner": "^1.7.4",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
-        "values-tools": "github:meaningalignment/values-tools#78d75e0e66eb1ac39e5efeca50affec9f32d6de6",
         "ws": "^8.20.0",
         "zod": "^3.25.76",
       },
@@ -73,7 +70,6 @@
         "@testing-library/react": "^16.3.2",
         "@types/bun": "^1.3.13",
         "@types/d3": "^7.4.3",
-        "@types/density-clustering": "^1.3.3",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
         "@types/react-syntax-highlighter": "^15.5.13",
@@ -95,8 +91,6 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
-
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.76", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA=="],
 
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.111", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-gzdRuEH9Mqeuu8zG6j4of3EH3fFJUI0UIubyeaA8gep6KzhCJF7uaTfagSE7x2vLAf381g/NrxsXhhH7Hon9iA=="],
 
@@ -822,8 +816,6 @@
 
     "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
 
-    "@types/density-clustering": ["@types/density-clustering@1.3.3", "", {}, "sha512-p2zEz57kHxWVg39XZ9QQVW6ity4rC3/1cCeLqm2eqqomvOrf8CFYaw7jO8gdYuchO4532ak0Z0f/vBr9irwG/w=="],
-
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -1245,8 +1237,6 @@
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
-
-    "density-clustering": ["density-clustering@1.3.0", "", {}, "sha512-icpmBubVTwLnsaor9qH/4tG5+7+f61VcqMN3V3pm9sxxSCt2Jcs0zWOgwZW9ARJYaKD3FumIgHiMOcIMRRAzFQ=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -2545,8 +2535,6 @@
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "validator": ["validator@13.15.35", "", {}, "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw=="],
-
-    "values-tools": ["values-tools@github:meaningalignment/values-tools#78d75e0", { "dependencies": { "@types/density-clustering": "^1.3.3", "density-clustering": "^1.3.0", "zod": "^3.25.76", "zod-to-json-schema": "^3.24.6" }, "peerDependencies": { "@ai-sdk/anthropic": ">=3", "@ai-sdk/openai": ">=3", "ai": ">=3 <7", "bun": "latest", "react": "latest" }, "optionalPeers": ["bun", "react"] }, "meaningalignment-values-tools-78d75e0", "sha512-lZmKbrcd+r9Y6bWMLe7K93J3kML8tSqAkXX2fo4TU3jj3oNMEqG8liVU+bWJ4H/5dez2I/WDP5g38bQKyeTemQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "fixtures:transitions": "tsx scripts/build-transitions-fixture.ts"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.76",
     "@ai-sdk/openai": "^3.0.63",
     "@ai-sdk/react": "^3.0.178",
     "@neondatabase/serverless": "^1.1.0",
@@ -80,7 +79,6 @@
     "sonner": "^1.7.4",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
-    "values-tools": "github:meaningalignment/values-tools#78d75e0e66eb1ac39e5efeca50affec9f32d6de6",
     "ws": "^8.20.0",
     "zod": "^3.25.76"
   },

--- a/scripts/generate-graph.ts
+++ b/scripts/generate-graph.ts
@@ -1,14 +1,12 @@
-import { Value } from "values-tools/src/types"
+import { type Value } from "../app/lib/values-tools"
 import {
   generateContextsFromQuestion,
   generateQuestions,
 } from "../app/services/generation"
 import {
-  configureValuesTools,
   generateUpgrades,
   generateValueFromContext,
-  PromptCache,
-} from "values-tools"
+} from "../app/lib/values-tools"
 import fs from "fs/promises"
 
 type Upgrade = {
@@ -16,11 +14,6 @@ type Upgrade = {
   toId: number
   context: string
 }
-
-// Use local cache for prompts.
-configureValuesTools({
-  cache: new PromptCache(),
-})
 
 export async function generateGraph(
   topic: string,

--- a/tests/helpers/setup.ts
+++ b/tests/helpers/setup.ts
@@ -1,10 +1,5 @@
 import "dotenv/config"
-import { configureValuesTools, PromptCache } from "values-tools"
 
-// Use GPT-4o for all values-tools calls in tests (the package's default
-// is Claude, which would require ANTHROPIC_API_KEY).
-configureValuesTools({
-  defaultModel: process.env.VALUES_TOOLS_MODEL ?? "gpt-5",
-  defaultTemperature: 1,
-  cache: new PromptCache(),
-})
+// values-tools is now in-repo (app/lib/values-tools). It reads
+// VALUES_TOOLS_MODEL at module load time and routes everything through
+// OpenAI, so there's nothing to configure here.

--- a/tests/pipeline/dedup-dryrun.fixture.ts
+++ b/tests/pipeline/dedup-dryrun.fixture.ts
@@ -16,7 +16,6 @@
 import "dotenv/config"
 import url from "node:url"
 import { neon } from "@neondatabase/serverless"
-import { configureValuesTools, PromptCache } from "values-tools"
 import {
   judgeCluster,
   ClusterVerdict,
@@ -24,11 +23,7 @@ import {
 import { partitionValues } from "~/services/deduplication/prompt-dedup"
 import { c, head, pass, fail, warn } from "../helpers/colors"
 
-configureValuesTools({
-  defaultModel: process.env.VALUES_TOOLS_MODEL ?? "gpt-5",
-  defaultTemperature: 1,
-  cache: new PromptCache(),
-})
+// values-tools is now in-repo at `app/lib/values-tools`; nothing to wire up.
 
 type Card = {
   id: number

--- a/tests/pipeline/dedup.fixture.ts
+++ b/tests/pipeline/dedup.fixture.ts
@@ -16,20 +16,14 @@ import "dotenv/config"
 import path from "node:path"
 import fs from "node:fs"
 import url from "node:url"
-import { configureValuesTools, PromptCache } from "values-tools"
 import { c, head, pass, fail, warn } from "../helpers/colors"
 import { judgeAreEquivalent } from "~/services/deduplication/in-repo-judge"
 import { partitionValues } from "~/services/deduplication/prompt-dedup"
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 
-// Pin to OpenAI so the fixture works without an ANTHROPIC_API_KEY.
-// gpt-5 / reasoning models require temperature=1, so set it here.
-configureValuesTools({
-  defaultModel: process.env.VALUES_TOOLS_MODEL ?? "gpt-5",
-  defaultTemperature: 1,
-  cache: new PromptCache(),
-})
+// values-tools is now in-repo at `app/lib/values-tools` and routes through
+// OpenAI; nothing to configure here.
 
 type FixtureCard = {
   id: string


### PR DESCRIPTION
Participant flow:
- Replace h-screen w-screen with min-h-screen w-full overflow-x-hidden so
  pages scroll naturally on small viewports.
- Smaller serif headings on phones (sm:text-4xl etc), tighter horizontal
  padding (mx-4 sm:mx-8, px-2 sm:px-8).
- Question cards: stack to single column on mobile.
- ValuesCard: full-width with max-w-sm cap; reduced inner padding so the
  card no longer overflows narrow phones.
- Carousel: card width 80vw on mobile so neighbouring cards remain visible.
- Chat: trim pb-[200px] to 180px on mobile, respect iOS safe-area-inset
  on the floating prompt panel.
- Dev "Seed random value" link moves to top-right so it doesn't sit on top
  of the chat input panel on phones.
- Link/voting page: switch the radio block from max-w-xs to max-w-md and
  drop the desktop-only avatar gutter.
- Moral graph page: settings sidebar becomes a slide-in drawer with a
  floating settings button on mobile.

Dashboard:
- Top breadcrumb scrolls horizontally and truncates the deliberation
  title on small screens instead of overflowing.
- Chats / votes / hypotheses split-views: aside is full-width on mobile
  and only one side (list or detail) is visible at a time. Detail pane
  gets a sticky "Back" link that returns to the list.
- Index page action rows + reset/delete row stack on mobile.
- Values filter row stacks on mobile.
- Simulate dialog gets a max-h-[90vh] + viewport-aware width so it fits
  small screens.

Other:
- Inline simple string-equality clustering for context dedup (replaces
  values-tools' deduplicateContexts, which routes through Anthropic
  regardless of the configured defaultModel and was breaking
  gen-seed-contexts in production).
- Add hide-scrollbar utility class for the new horizontally-scrolling
  breadcrumb.

https://claude.ai/code/session_01SJXduWN129VhRoFUR8y7Lt