### PR TITLE
Fix SSE streaming by installing native fetch globals at runtime

### DIFF
--- a/app/config.server.ts
+++ b/app/config.server.ts
@@ -1,3 +1,14 @@
+import { installGlobals } from "@remix-run/node"
+
+// vite.config.ts only runs at build/dev time, so its installGlobals call does
+// not reach the deployed Vercel function. Without this runtime call, Remix's
+// default `@remix-run/web-fetch` polyfill stays installed and Response.body is
+// a web-streams-polyfill ReadableStream — pipeThrough'ing it with a native
+// TextDecoderStream (what ai@6 does for SSE) throws "First parameter has
+// member 'readable' that is not a ReadableStream" and breaks streamText in
+// /api/chat-assistant.
+installGlobals({ nativeFetch: true })
+
 import { PrismaClient, Prisma } from "@prisma/client"
 import { cowpunkify } from "cowpunk-auth"
 import { Inngest } from "inngest"

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "mge",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.63",
-        "@ai-sdk/react": "^3.0.178",
+        "@ai-sdk/react": "^3.0.179",
         "@neondatabase/serverless": "^1.1.0",
         "@prisma/adapter-neon": "^7.8.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -30,7 +30,7 @@
         "@types/ws": "^8.18.1",
         "@vercel/analytics": "^1.6.1",
         "@vercel/kv": "^1.0.1",
-        "ai": "^6.0.176",
+        "ai": "^6.0.177",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cowpunk-auth": "^0.0.7",
@@ -92,7 +92,7 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.111", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-gzdRuEH9Mqeuu8zG6j4of3EH3fFJUI0UIubyeaA8gep6KzhCJF7uaTfagSE7x2vLAf381g/NrxsXhhH7Hon9iA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.112", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@3.0.63", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA=="],
 
@@ -100,7 +100,7 @@
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.27", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw=="],
 
-    "@ai-sdk/react": ["@ai-sdk/react@3.0.178", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.176", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-fLkT2fD8Bgi8nsp16PKL6UOiAIwZiwCfv+jXRhOikx0nIh3AdtaGUqJ1yqig7BXg5F9oxHmiaD7YpLC2fN/arQ=="],
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.179", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.27", "ai": "6.0.177", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-wq3gqDrwi6QvwHQuVrTpjeUQI/LHZ5ysokWTIS1hOFw0UIIX8eVpri5iVvqQuq5CeQw/6bYXSI15SfMtZJixpQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -938,7 +938,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@6.0.176", "", { "dependencies": { "@ai-sdk/gateway": "3.0.111", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-dhxDef3VCIxaFr6tKyG0BrkkCelmnporlen8nHajIwCk7S4PvIaSVI/iyJenhFOZ9KBoKjCAoUs6TzZ3yrSjxw=="],
+    "ai": ["ai@6.0.177", "", { "dependencies": { "@ai-sdk/gateway": "3.0.112", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.27", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.63",
-    "@ai-sdk/react": "^3.0.178",
+    "@ai-sdk/react": "^3.0.179",
     "@neondatabase/serverless": "^1.1.0",
     "@prisma/adapter-neon": "^7.8.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -52,7 +52,7 @@
     "@types/ws": "^8.18.1",
     "@vercel/analytics": "^1.6.1",
     "@vercel/kv": "^1.0.1",
-    "ai": "^6.0.176",
+    "ai": "^6.0.177",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cowpunk-auth": "^0.0.7",


### PR DESCRIPTION
## Summary
Fixes an issue where Server-Sent Events (SSE) streaming was broken in the deployed Vercel function due to incompatible ReadableStream polyfills.

## Key Changes
- Added `installGlobals({ nativeFetch: true })` call to `app/config.server.ts` at module load time
- This ensures native fetch globals are installed in the Vercel runtime environment, which only runs at request time (not build/dev time)

## Implementation Details
The `vite.config.ts` file's `installGlobals` call only executes during build/dev time and doesn't reach the deployed Vercel function. Without the runtime call in `config.server.ts`, Remix's default `@remix-run/web-fetch` polyfill remains active, providing a web-streams-polyfill ReadableStream.

When the `ai` package (v6) attempts to pipe this polyfilled ReadableStream through a native TextDecoderStream for SSE handling, it throws: "First parameter has member 'readable' that is not a ReadableStream", breaking the `streamText` function in `/api/chat-assistant`.

By installing native fetch globals at runtime with `nativeFetch: true`, the native ReadableStream is used instead, allowing proper interoperability with native stream APIs.

## Dependencies Updated
- `@ai-sdk/react`: ^3.0.178 → ^3.0.179
- `ai`: ^6.0.176 → ^6.0.177

https://claude.ai/code/session_0186LxYbJgJaKza8jXp8J75t