### PR TITLE
Bypass globalThis.fetch in chat-assistant: pin undici on the provider

### DIFF
--- a/app/config.server.ts
+++ b/app/config.server.ts
@@ -1,14 +1,3 @@
-import { installGlobals } from "@remix-run/node"
-
-// vite.config.ts only runs at build/dev time, so its installGlobals call does
-// not reach the deployed Vercel function. Without this runtime call, Remix's
-// default `@remix-run/web-fetch` polyfill stays installed and Response.body is
-// a web-streams-polyfill ReadableStream — pipeThrough'ing it with a native
-// TextDecoderStream (what ai@6 does for SSE) throws "First parameter has
-// member 'readable' that is not a ReadableStream" and breaks streamText in
-// /api/chat-assistant.
-installGlobals({ nativeFetch: true })
-
 import { PrismaClient, Prisma } from "@prisma/client"
 import { cowpunkify } from "cowpunk-auth"
 import { Inngest } from "inngest"

--- a/app/routes/api.chat-assistant.ts
+++ b/app/routes/api.chat-assistant.ts
@@ -1,6 +1,7 @@
 import { ActionFunctionArgs } from "@remix-run/node"
 import { streamText, tool, convertToModelMessages, UIMessage } from "ai"
-import { openai as aiOpenai } from "@ai-sdk/openai"
+import { createOpenAI } from "@ai-sdk/openai"
+import { fetch as undiciFetch } from "undici"
 import { z } from "zod"
 import { ensureLoggedIn } from "~/config.server"
 import {
@@ -17,6 +18,20 @@ export const config = { maxDuration: 300 }
 const MODEL_ID =
   process.env.OPENAI_ARTICULATION_MODEL ?? "gpt-5"
 const isReasoningModel = /^gpt-5|^o\d/.test(MODEL_ID)
+
+// Pin undici as the provider's fetch instead of going through globalThis.
+// @vercel/remix/server.js side-effect-imports ./globals.js, which calls
+// @remix-run/node's installGlobals() without nativeFetch — that swaps
+// globalThis.fetch for @remix-run/web-fetch, whose Response.body is a
+// web-streams-polyfill ReadableStream. ai@6's SSE parser then does
+// `body.pipeThrough(new TextDecoderStream())` and the polyfill rejects
+// the native TransformStream ("First parameter has member 'readable'
+// that is not a ReadableStream"). Doing it via createOpenAI sidesteps
+// the global state regardless of bundle/module load order.
+const aiOpenai = createOpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  fetch: undiciFetch as unknown as typeof globalThis.fetch,
+})
 
 export async function action({ request }: ActionFunctionArgs) {
   const authorId = await ensureLoggedIn(request)


### PR DESCRIPTION
The previous fix tried to re-run installGlobals({ nativeFetch: true }) at runtime from config.server.ts, but that's racy: @vercel/remix's runtime entry (@vercel/remix/server.js line 15) does require('./globals.js'), which side-effect-calls @remix-run/node's installGlobals() WITHOUT nativeFetch. Depending on whether the user bundle is required before or after @vercel/remix/server, our re-install either wins or gets clobbered — and on this deploy it gets clobbered, so globalThis.fetch stayed pointed at @remix-run/web-fetch and we kept hitting the same web-streams-polyfill pipeThrough error.

Drop the unreliable global re-install. Instead, build the provider with createOpenAI({ fetch: undici.fetch }) so the AI SDK never reads globalThis.fetch at all. undici is already a transitive dep via @remix-run/node, and its Response.body is a native ReadableStream, which pipeThrough's cleanly with a native TextDecoderStream.

Order-independent: works regardless of whether @vercel/remix's globals run before or after our route module.